### PR TITLE
Difficulty

### DIFF
--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -6,6 +6,8 @@ import { StrategyEnum } from "./Sudoku"
 import { Cell } from "./Cell";
 import { Group } from "./Group";
 
+const GAME_LENGTH_DIFFICULTY_MULTIPLIER: number = 0.02;
+
 /**
  * Constructed using board string
  * Throws exception if invalid board
@@ -21,6 +23,7 @@ export class Board{
     private solution: string[][];
     private solutionString: string;
     private mostDifficultStrategy: StrategyEnum;
+    private difficulty: number;
     private solver: Solver;
 
     /**
@@ -43,6 +46,7 @@ export class Board{
         this.board = getBoardArray(board);
 
         this.mostDifficultStrategy = -1;
+        this.difficulty = 0;
 
         if (algorithm === undefined) {
             this.solver = new Solver(this.board);
@@ -87,11 +91,22 @@ export class Board{
     }
 
     /**
+     * Get difficulty
+     * @returns difficulty
+     */
+    public getDifficulty():number {
+        return this.difficulty;
+    }
+
+    /**
      * Solves the puzzle and sets strategy and solution
      */
     private solve():void {
         let hint:Hint = this.solver.nextStep();
+        let stepCount:number = 0;
         while (hint !== null) {
+            this.difficulty += hint.getDifficulty();
+            stepCount++;
             if (hint.getStrategyType() > this.mostDifficultStrategy) {
                 this.mostDifficultStrategy = hint.getStrategyType();
             }
@@ -99,6 +114,8 @@ export class Board{
         }
         this.solution = this.solver.getSolution();
         this.setSolutionString();
+        this.difficulty /= stepCount;
+        this.difficulty = Math.ceil(this.difficulty * (1 + (stepCount * GAME_LENGTH_DIFFICULTY_MULTIPLIER)));
         return;
     }
 

--- a/Generator/Hint.ts
+++ b/Generator/Hint.ts
@@ -128,6 +128,14 @@ export class Hint{
     }
 
     /**
+     * Gets strategy difficulty
+     * @returns strategy difficulty
+     */
+    public getDifficulty():number {
+        return this.strategy.getDifficulty();
+    }
+
+    /**
      * Gets cells that "cause" strategy to be applicable
      * @returns cells "causing" strategy
      */

--- a/Generator/Strategy.ts
+++ b/Generator/Strategy.ts
@@ -4,6 +4,38 @@ import { SudokuEnum, StrategyEnum, getCellsInRow, getCellsInColumn, getCellsInBo
 import { Group } from "./Group";
 
 /**
+ * Includes lower bounds for strategies difficulty ratings
+ * @enum
+ */
+enum DifficultyLowerBounds {
+    NAKED_SINGLE = 10,
+    HIDDEN_SINGLE = 20,
+    NAKED_PAIR = 40,
+    NAKED_TRIPLET = 60,
+    NAKED_QUADRUPLET = 90,
+    NAKED_QUINTUPLET = 140,
+    NAKED_SEXTUPLET = 200,
+    NAKED_SEPTUPLET = 300,
+    NAKED_OCTUPLET = 450
+}
+
+/**
+ * Includes upper bounds for strategies difficulty ratings
+ * @enum
+ */
+enum DifficultyUpperBounds {
+    NAKED_SINGLE = 10,
+    HIDDEN_SINGLE = 40,
+    NAKED_PAIR = 60,
+    NAKED_TRIPLET = 90,
+    NAKED_QUADRUPLET = 140,
+    NAKED_QUINTUPLET = 140,
+    NAKED_SEXTUPLET = 200,
+    NAKED_SEPTUPLET = 300,
+    NAKED_OCTUPLET = 450
+}
+
+/**
  * Constructed using 2d array of cells
  * Returns:
  * Whether or object constitutes specific strategies

--- a/Generator/Strategy.ts
+++ b/Generator/Strategy.ts
@@ -57,6 +57,8 @@ export class Strategy{
     private strategyType: number;
     // Whether or not strategy has been identified and ready to use
     private identified: boolean;
+    // Stores number representing its difficulty rating (calculated to be in between the strategies upper/lower bounds)
+    private difficulty: number;
 
     /**
      * Cell object using cells the strategy acts on
@@ -125,6 +127,81 @@ export class Strategy{
     }
 
     /**
+     * Gets difficulty rating for the strategy represented as an integer
+     * @returns difficulty int
+     * @throws {@link CustomError}
+     * Thrown if strategy hasn't been identified
+     */
+    public getDifficulty():number {
+        this.verifyIdentified();
+        return this.difficulty;
+    }
+
+    /**
+     * Given a tuple like pair returns the difficulty lower bound for that naked set like naked pair
+     * @param tuple - tuple e.g. naked single, pair, ...
+     * @returns lower bound for naked single of given tuple
+     */
+    private getNakedSetDifficultyLowerBound(tuple: TupleEnum):DifficultyLowerBounds {
+        if (tuple === TupleEnum.SINGLE) {
+            return DifficultyLowerBounds.NAKED_SINGLE;
+        }
+        else if (tuple === TupleEnum.PAIR) {
+            return DifficultyLowerBounds.NAKED_PAIR;
+        }
+        else if (tuple === TupleEnum.TRIPLET) {
+            return DifficultyLowerBounds.NAKED_TRIPLET;
+        }
+        else if (tuple === TupleEnum.QUADRUPLET) {
+            return DifficultyLowerBounds.NAKED_QUADRUPLET;
+        }
+        else if (tuple === TupleEnum.QUINTUPLET) {
+            return DifficultyLowerBounds.NAKED_QUINTUPLET;
+        }
+        else if (tuple === TupleEnum.SEXTUPLET) {
+            return DifficultyLowerBounds.NAKED_SEXTUPLET;
+        }
+        else if (tuple === TupleEnum.SEPTUPLET) {
+            return DifficultyLowerBounds.NAKED_SEPTUPLET;
+        }
+        else if (tuple === TupleEnum.OCTUPLET) {
+            return DifficultyLowerBounds.NAKED_OCTUPLET;
+        }
+    }
+
+    /**
+     * Given a tuple like pair returns the difficulty upper bound for that naked set like naked pair
+     * @param tuple - tuple e.g. naked single, pair, ...
+     * @returns upper bound for naked single of given tuple
+     */
+    private getNakedSetDifficultyUpperBound(tuple: TupleEnum):DifficultyUpperBounds {
+        if (tuple === TupleEnum.SINGLE) {
+            return DifficultyUpperBounds.NAKED_SINGLE;
+        }
+        else if (tuple === TupleEnum.PAIR) {
+            return DifficultyUpperBounds.NAKED_PAIR;
+        }
+        else if (tuple === TupleEnum.TRIPLET) {
+            return DifficultyUpperBounds.NAKED_TRIPLET;
+        }
+        else if (tuple === TupleEnum.QUADRUPLET) {
+            return DifficultyUpperBounds.NAKED_QUADRUPLET;
+        }
+        else if (tuple === TupleEnum.QUINTUPLET) {
+            return DifficultyUpperBounds.NAKED_QUINTUPLET;
+        }
+        else if (tuple === TupleEnum.SEXTUPLET) {
+            return DifficultyUpperBounds.NAKED_SEXTUPLET;
+        }
+        else if (tuple === TupleEnum.SEPTUPLET) {
+            return DifficultyUpperBounds.NAKED_SEPTUPLET;
+        }
+        else if (tuple === TupleEnum.OCTUPLET) {
+            return DifficultyUpperBounds.NAKED_OCTUPLET;
+        }
+    }
+
+    /**
      * Checks if strategy is a naked set of given tuple and if so adds values that can be placed
      * @param tuple - e.g. could be single or pair for naked single or naked pair respectively
      * @returns true if strategy is a naked tuple
@@ -171,6 +248,7 @@ export class Strategy{
                                 this.values.push(new Cell(row, column, single));
                                 this.strategyType = StrategyEnum.NAKED_SINGLE;
                                 this.identified = true;
+                                this.difficulty = DifficultyLowerBounds.NAKED_SINGLE;
                                 return true;
                             }
                             // Adds notes to remove if there are any to remove
@@ -187,6 +265,30 @@ export class Strategy{
                             if (this.notes.length > 0) {
                                 this.strategyType = StrategyEnum[StrategyEnum[tuple]];
                                 this.identified = true;
+                                // Calculate difficulty based on how far apart the naked set cells are
+                                let distanceRatio:number;
+                                if (group === GroupEnum.ROW) {
+                                    distanceRatio = nakedSet[nakedSet.length - 1].getRow() - nakedSet[0].getRow();
+                                    distanceRatio /= SudokuEnum.COLUMN_LENGTH - 1;
+                                }
+                                else if (group === GroupEnum.COLUMN) {
+                                    distanceRatio = nakedSet[nakedSet.length - 1].getColumn() - nakedSet[0].getColumn();
+                                    distanceRatio /= SudokuEnum.ROW_LENGTH - 1;
+                                }
+                                else {
+                                    let minRow:number = SudokuEnum.COLUMN_LENGTH, minColumn:number = SudokuEnum.ROW_LENGTH;
+                                    let maxRow:number = 0, maxColumn:number = 0;
+                                    for (let k:number = 0; k < nakedSet.length; k++) {
+                                        minRow = Math.min(minRow, nakedSet[k].getRow());
+                                        minColumn = Math.min(minColumn, nakedSet[k].getColumn());
+                                        maxRow = Math.max(maxRow, nakedSet[k].getRow());
+                                        maxColumn = Math.max(maxColumn, nakedSet[k].getColumn());
+                                    }
+                                    distanceRatio = (maxRow - minRow) + (maxColumn - minColumn);
+                                    distanceRatio /= (SudokuEnum.BOX_LENGTH - 1) * 2;
+                                }
+                                this.difficulty = this.getNakedSetDifficultyLowerBound(tuple);
+                                this.difficulty += Math.ceil(distanceRatio * (this.getNakedSetDifficultyUpperBound(tuple) - this.getNakedSetDifficultyLowerBound(tuple)));
                                 // If naked set shares a row or column it might also share a box so skip to check that
                                 if (group !== GroupEnum.BOX) {
                                     // Set used row or column to avoiding adding same cells notes twice
@@ -216,8 +318,8 @@ export class Strategy{
                                             }
                                         }
                                     }
-                                    return true;
                                 }
+                                return this.identified;
                             }
                         }
                     }
@@ -245,6 +347,8 @@ export class Strategy{
         // stores possible hidden single for each candidate at their corresponding index
         // initialized to null, set to cell with hidden single, reset to null if multiple cells with note found
         let single:Cell[] = new Array(SudokuEnum.ROW_LENGTH).fill(null);
+        // Stores total number of notes in cells in the group to be used to calculate the difficulty
+        let noteCount:number = 0;
 
         let notes:Group;
         let row:number, column:number;
@@ -253,6 +357,7 @@ export class Strategy{
             for (let j:number = 0; j < this.cells[i].length; j++) {
                 // Checks each note of the cell
                 notes = this.cells[i][j].getNotes();
+                noteCount += notes.getSize();
                 for (let note:number = 0; note < SudokuEnum.ROW_LENGTH; note++) {
                     if (notes.contains(note)) {
                         // Add cell to hidden single Cell if this note not found before, otherwise set to null
@@ -272,10 +377,15 @@ export class Strategy{
         // Checks if a hidden single was found
         for (let i:number = 0; i < SudokuEnum.ROW_LENGTH; i++) {
             if (found.contains(i) && single[i] !== null) {
-                // Identify strategy and return that it is a hidden single
+                // Identify strategy, calculate difficulty, and return that it is a hidden single
                 this.values.push(single[i]);
                 this.strategyType = StrategyEnum.HIDDEN_SINGLE;
                 this.identified = true;
+                // Calculate ratio of noteCount to total possible note count in a group
+                let noteRatio:number = noteCount / (SudokuEnum.ROW_LENGTH * SudokuEnum.ROW_LENGTH);
+                // Set difficulty to hidden single lower bound adjusted upwards based on noteRatio
+                this.difficulty = DifficultyLowerBounds.HIDDEN_SINGLE;
+                this.difficulty += Math.ceil(noteRatio) * (DifficultyUpperBounds.HIDDEN_SINGLE - DifficultyLowerBounds.HIDDEN_SINGLE);
                 return true;
             }
         }

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -116,11 +116,25 @@ describe("create Board objects", () => {
     });
 });
 
+let singleNakedSingle:Board, onlyNakedSingles:Board, onlyNakedSinglesQuadruplets:Board;
+
 describe("solve Boards", () => {
+    beforeAll(() => {
+        singleNakedSingle = new Board(TestBoards.SINGLE_NAKED_SINGLE);
+        onlyNakedSingles = new Board(TestBoards.ONLY_NAKED_SINGLES);
+        let algorithm:StrategyEnum[] = new Array();
+        algorithm.push(StrategyEnum.NAKED_QUADRUPLET);
+        for (let strategy: number = 0; strategy < StrategyEnum.COUNT; strategy++) {
+            if (strategy !== StrategyEnum.NAKED_QUADRUPLET) {
+                algorithm.push(strategy);
+            }
+        }
+        onlyNakedSinglesQuadruplets = new Board(TestBoards.ONLY_NAKED_SINGLES, algorithm);
+    });
+
     it('should solve single naked single', () => {
-        let board:Board = new Board(TestBoards.SINGLE_NAKED_SINGLE);
-        expect(board.getSolutionString()).toBe(TestBoards.SINGLE_NAKED_SINGLE_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
+        expect(singleNakedSingle.getSolutionString()).toBe(TestBoards.SINGLE_NAKED_SINGLE_SOLUTION);
+        expect(singleNakedSingle.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
     });
 
     it('should solve single naked single using hidden single', () => {
@@ -132,9 +146,12 @@ describe("solve Boards", () => {
     });
 
     it('should solve naked singles only board', () => {
-        let board:Board = new Board(TestBoards.ONLY_NAKED_SINGLES);
-        expect(board.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
+        expect(onlyNakedSingles.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
+        expect(onlyNakedSingles.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
+    });
+
+    it('should give higher difficulty rating to board with multiple naked singles than one with only one', () => {
+        expect(onlyNakedSingles.getDifficulty()).toBeGreaterThan(singleNakedSingle.getDifficulty());
     });
 
     it ('should solve row hidden single', () => {
@@ -181,16 +198,12 @@ describe("solve Boards", () => {
     });
 
     it('should solve naked quadruplet', () => {
-        let algorithm:StrategyEnum[] = new Array();
-        algorithm.push(StrategyEnum.NAKED_QUADRUPLET);
-        for (let strategy: number = 0; strategy < StrategyEnum.COUNT; strategy++) {
-            if (strategy !== StrategyEnum.NAKED_QUADRUPLET) {
-                algorithm.push(strategy);
-            }
-        }
-        let board:Board = new Board(TestBoards.ONLY_NAKED_SINGLES, algorithm);
-        expect(board.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_QUADRUPLET);
+        expect(onlyNakedSinglesQuadruplets.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
+        expect(onlyNakedSinglesQuadruplets.getStrategyScore()).toBe(StrategyEnum.NAKED_QUADRUPLET);
+    });
+
+    it('should give a higher difficulty score to solving same board with naked quadruplets than singles', () => {
+        expect(onlyNakedSinglesQuadruplets.getDifficulty()).toBeGreaterThan(onlyNakedSingles.getDifficulty());
     });
 
     it('should solve naked quintuplet', () => {


### PR DESCRIPTION
Added difficulty to Board along with tests. Difficulties added to individual strategies in Strategy and getter added to Hint to communicate it to Board. Difficulty methodology described below.

Each strategy has a lower and upper bound difficulty rating. When the Strategy class finds a strategy in the board it assigns it a rating in between those bounds (e.g. a naked pair that is really far apart would have a higher rating than one that is right next to each other). Hint objects will then have a getter that returns the difficulty rating of the strategy used. Finally, the Board class keeps a running total of all the difficulty ratings of all the strategies used by Solver to solve the board. It will then divide that sum by the number of steps (that way a bunch of naked singles won't be harder than a couple xwings). Finally, it will multiply this quotient by a number equal to 1 plus the number of steps times some constant e.g. 0.02 so that longer puzzles will still be considered harder than shorter puzzles e.g. 10 steps = 20% boost while 20 steps = 40% boost. This also ensures there is a diverse selection of strategies available at the different difficulty levels. Lastly, difficulty labels will be assigned after a bunch of boards are generated and some data analysis is done to draw up boundaries but before upload to the database.

Equation: (Strategy Rating Sum / Number of Steps) * (1 + (Constant * Number of steps))