### PR TITLE
Board strategy refactor

### DIFF
--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -149,19 +149,28 @@ export class Board{
      * Solves the puzzle and sets strategy and solution
      */
     private solve():void {
+        // Stores hint for current step
         let hint:Hint = this.solver.nextStep();
+        // Number of steps taken so far to solve the puzzle
         let stepCount:number = 0;
+        // Gets hint for each stop to solve puzzle (hint is null when board is finished being solved)
         while (hint !== null) {
+            // Records what strategy was used
             this.strategies[hint.getStrategyType()] = true;
+            // Updates difficulty rating based on how hard current step is
             this.difficulty += hint.getDifficulty();
             stepCount++;
+            // Updates most difficult strategy used
             if (hint.getStrategyType() > this.mostDifficultStrategy) {
                 this.mostDifficultStrategy = hint.getStrategyType();
             }
+            // Gets hint for next step
             hint = this.solver.nextStep();
         }
+        // Sets solution string
         this.solution = this.solver.getSolution();
         this.setSolutionString();
+        // Adds prereqs to strategies (strategies that current strategies could be reduced to)
         for (let i:number = 0; i < StrategyEnum.COUNT; i++) {
             if (this.strategies[i]) {
                 let prereqs:StrategyEnum[] = this.getPrereqs(StrategyEnum[StrategyEnum[i]]);
@@ -170,6 +179,7 @@ export class Board{
                 }
             }
         }
+        // Adjusts difficulty for game length
         this.difficulty /= stepCount;
         this.difficulty = Math.ceil(this.difficulty * (1 + (stepCount * GAME_LENGTH_DIFFICULTY_MULTIPLIER)));
         return;

--- a/Generator/Hint.ts
+++ b/Generator/Hint.ts
@@ -1,6 +1,7 @@
 import { Cell } from "./Cell";
 import { Group } from "./Group";
 import { Strategy } from "./Strategy";
+import { StrategyEnum } from "./Sudoku";
 
 /**
  * Contains hint information for naked single strategy
@@ -113,10 +114,47 @@ export class Hint{
      * @param info - Hint info
      * @param action - Hint action
      */
-    constructor(strategy: Strategy, info: string, action: string) {
+    constructor(strategy: Strategy) {
         this.strategy = strategy;
-        this.info = info;
-        this.action = action;
+        if (this.getStrategyType() === StrategyEnum.NAKED_SINGLE) {
+            this.info = NAKED_SINGLE.HINT_INFO;
+            this.action = NAKED_SINGLE.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.NAKED_PAIR) {
+            this.info = NAKED_PAIR.HINT_INFO;
+            this.action = NAKED_PAIR.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.NAKED_TRIPLET) {
+            this.info = NAKED_TRIPLET.HINT_INFO;
+            this.action = NAKED_TRIPLET.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.NAKED_QUADRUPLET) {
+            this.info = NAKED_QUADRUPLET.HINT_INFO;
+            this.action = NAKED_QUADRUPLET.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.NAKED_QUINTUPLET) {
+            this.info = NAKED_QUINTUPLET.HINT_INFO;
+            this.action = NAKED_QUINTUPLET.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.NAKED_SEXTUPLET) {
+            this.info = NAKED_SEXTUPLET.HINT_INFO;
+            this.action = NAKED_SEXTUPLET.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.NAKED_SEPTUPLET) {
+            this.info = NAKED_SEPTUPLET.HINT_INFO;
+            this.action = NAKED_SEPTUPLET.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.NAKED_OCTUPLET) {
+            this.info = NAKED_OCTUPLET.HINT_INFO;
+            this.action = NAKED_OCTUPLET.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.HIDDEN_SINGLE) {
+            this.info = HIDDEN_SINGLE.HINT_INFO;
+            this.action = HIDDEN_SINGLE.HINT_ACTION;
+        }
+        else {
+            throw new Error();
+        }
     }
 
     /**
@@ -173,86 +211,5 @@ export class Hint{
      */
     public getAction():string {
         return this.action;
-    }
-}
-
-/**
- * Naked single strategy hint class
- */
-export class NakedSingleHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, NAKED_SINGLE.HINT_INFO, NAKED_SINGLE.HINT_ACTION);
-    }
-}
-
-/**
- * Hidden single strategy hint class
- */
-export class HiddenSingleHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, HIDDEN_SINGLE.HINT_INFO, HIDDEN_SINGLE.HINT_ACTION);
-    }
-}
-
-/**
- * Naked pair strategy hint class
- */
-export class NakedPairHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, NAKED_PAIR.HINT_INFO, NAKED_PAIR.HINT_ACTION);
-    }
-}
-
-/**
- * Naked triplet strategy hint class
- */
-export class NakedTripletHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, NAKED_TRIPLET.HINT_INFO, NAKED_TRIPLET.HINT_ACTION);
-    }
-}
-
-/**
- * Naked quadruplet strategy hint class
- */
-export class NakedQuadrupletHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, NAKED_QUADRUPLET.HINT_INFO, NAKED_QUADRUPLET.HINT_ACTION);
-    }
-}
-
-/**
- * Naked quintuplet strategy hint class
- */
-export class NakedQuintupletHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, NAKED_QUINTUPLET.HINT_INFO, NAKED_QUINTUPLET.HINT_ACTION);
-    }
-}
-
-/**
- * Naked sextuplet strategy hint class
- */
-export class NakedSextupletHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, NAKED_SEXTUPLET.HINT_INFO, NAKED_SEXTUPLET.HINT_ACTION);
-    }
-}
-
-/**
- * Naked septuplet strategy hint class
- */
-export class NakedSeptupletHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, NAKED_SEPTUPLET.HINT_INFO, NAKED_SEPTUPLET.HINT_ACTION);
-    }
-}
-
-/**
- * Naked octuplet strategy hint class
- */
-export class NakedOctupletHint extends Hint {
-    constructor(strategy: Strategy) {
-        super(strategy, NAKED_OCTUPLET.HINT_INFO, NAKED_OCTUPLET.HINT_ACTION);
     }
 }

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -2,7 +2,7 @@ import { Cell } from "./Cell";
 import { CustomError, CustomErrorEnum } from "./CustomError";
 import { Strategy } from "./Strategy";
 import { SudokuEnum, StrategyEnum } from "./Sudoku";
-import { HiddenSingleHint, Hint, NakedPairHint, NakedSingleHint, NakedTripletHint, NakedQuadrupletHint, NakedQuintupletHint, NakedSextupletHint, NakedSeptupletHint, NakedOctupletHint } from "./Hint";
+import { Hint } from "./Hint";
 import { Group } from "./Group";
 
 /**
@@ -137,7 +137,7 @@ export class Solver{
     private setHiddenSingle(cells: Cell[][]):boolean {
         let hiddenSingle: Strategy = new Strategy(this.board, cells);
         if (hiddenSingle.setStrategyType(StrategyEnum.HIDDEN_SINGLE)) {
-            this.hint = new HiddenSingleHint(hiddenSingle);
+            this.hint = new Hint(hiddenSingle);
             return true;
         }
         return false;
@@ -151,7 +151,7 @@ export class Solver{
     private setNakedSingle(cells: Cell[][]):boolean {
         let nakedSingle: Strategy = new Strategy(this.board, cells);
         if (nakedSingle.setStrategyType(StrategyEnum.NAKED_SINGLE)) {
-            this.hint = new NakedSingleHint(nakedSingle);
+            this.hint = new Hint(nakedSingle);
             return true;
         }
         return false;
@@ -165,7 +165,7 @@ export class Solver{
     private setNakedPair(cells: Cell[][]):boolean {
         let nakedPair: Strategy = new Strategy(this.board, cells);
         if (nakedPair.setStrategyType(StrategyEnum.NAKED_PAIR)) {
-            this.hint = new NakedPairHint(nakedPair);
+            this.hint = new Hint(nakedPair);
             return true;
         }
         return false;
@@ -179,7 +179,7 @@ export class Solver{
     private setNakedTriplet(cells: Cell[][]):boolean {
         let nakedTriplet: Strategy = new Strategy(this.board, cells);
         if (nakedTriplet.setStrategyType(StrategyEnum.NAKED_TRIPLET)) {
-            this.hint = new NakedTripletHint(nakedTriplet);
+            this.hint = new Hint(nakedTriplet);
             return true;
         }
         return false;
@@ -193,7 +193,7 @@ export class Solver{
     private setNakedQuadruplet(cells: Cell[][]):boolean {
         let nakedQuadruplet: Strategy = new Strategy(this.board, cells);
         if (nakedQuadruplet.setStrategyType(StrategyEnum.NAKED_QUADRUPLET)) {
-            this.hint = new NakedQuadrupletHint(nakedQuadruplet);
+            this.hint = new Hint(nakedQuadruplet);
             return true;
         }
         return false;
@@ -207,7 +207,7 @@ export class Solver{
     private setNakedQuintuplet(cells: Cell[][]):boolean {
         let nakedQuintuplet: Strategy = new Strategy(this.board, cells);
         if (nakedQuintuplet.setStrategyType(StrategyEnum.NAKED_QUINTUPLET)) {
-            this.hint = new NakedQuintupletHint(nakedQuintuplet);
+            this.hint = new Hint(nakedQuintuplet);
             return true;
         }
         return false;
@@ -221,7 +221,7 @@ export class Solver{
     private setNakedSextuplet(cells: Cell[][]):boolean {
         let nakedSextuplet: Strategy = new Strategy(this.board, cells);
         if (nakedSextuplet.setStrategyType(StrategyEnum.NAKED_SEXTUPLET)) {
-            this.hint = new NakedSextupletHint(nakedSextuplet);
+            this.hint = new Hint(nakedSextuplet);
             return true;
         }
         return false;
@@ -235,7 +235,7 @@ export class Solver{
     private setNakedSeptuplet(cells: Cell[][]):boolean {
         let nakedSeptuplet: Strategy = new Strategy(this.board, cells);
         if (nakedSeptuplet.setStrategyType(StrategyEnum.NAKED_SEPTUPLET)) {
-            this.hint = new NakedSeptupletHint(nakedSeptuplet);
+            this.hint = new Hint(nakedSeptuplet);
             return true;
         }
         return false;
@@ -249,7 +249,7 @@ export class Solver{
     private setNakedOctuplet(cells: Cell[][]):boolean {
         let nakedOctuplet: Strategy = new Strategy(this.board, cells);
         if (nakedOctuplet.setStrategyType(StrategyEnum.NAKED_OCTUPLET)) {
-            this.hint = new NakedOctupletHint(nakedOctuplet);
+            this.hint = new Hint(nakedOctuplet);
             return true;
         }
         return false;

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -88,32 +88,10 @@ export class Solver{
      */
     private setHint(cells: Cell[][]):void {
         // Attempts to use strategies in order specified by algorithm
+        let strategy:Strategy = new Strategy(this.board, cells);
         for (let i: number = 0; i < StrategyEnum.COUNT; i++) {
-            if (this.algorithm[i] === StrategyEnum.NAKED_SINGLE && this.setNakedSingle(cells)) {
-                return;
-            }
-            else if (this.algorithm[i] === StrategyEnum.HIDDEN_SINGLE && this.setHiddenSingle(cells)) {
-                return;
-            }
-            else if (this.algorithm[i] === StrategyEnum.NAKED_PAIR && this.setNakedPair(cells)) {
-                return;
-            }
-            else if (this.algorithm[i] === StrategyEnum.NAKED_TRIPLET && this.setNakedTriplet(cells)) {
-                return;
-            }
-            else if (this.algorithm[i] === StrategyEnum.NAKED_QUADRUPLET && this.setNakedQuadruplet(cells)) {
-                return;
-            }
-            else if (this.algorithm[i] === StrategyEnum.NAKED_QUINTUPLET && this.setNakedQuintuplet(cells)) {
-                return;
-            }
-            else if (this.algorithm[i] === StrategyEnum.NAKED_SEXTUPLET && this.setNakedSextuplet(cells)) {
-                return;
-            }
-            else if (this.algorithm[i] === StrategyEnum.NAKED_SEPTUPLET && this.setNakedSeptuplet(cells)) {
-                return;
-            }
-            else if (this.algorithm[i] === StrategyEnum.NAKED_OCTUPLET && this.setNakedOctuplet(cells)) {
+            if (strategy.setStrategyType(this.algorithm[i])) {
+                this.hint = new Hint(strategy);
                 return;
             }
         }
@@ -127,132 +105,6 @@ export class Solver{
     private applyHint():void {
         this.placeValues(this.hint.getEffectPlacements());
         this.removeNotes(this.hint.getEffectRemovals());
-    }
-
-    /**
-     * Returns true if puzzle has a hidden single and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a hidden single
-     */
-    private setHiddenSingle(cells: Cell[][]):boolean {
-        let hiddenSingle: Strategy = new Strategy(this.board, cells);
-        if (hiddenSingle.setStrategyType(StrategyEnum.HIDDEN_SINGLE)) {
-            this.hint = new Hint(hiddenSingle);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has a naked single and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a naked single
-     */
-    private setNakedSingle(cells: Cell[][]):boolean {
-        let nakedSingle: Strategy = new Strategy(this.board, cells);
-        if (nakedSingle.setStrategyType(StrategyEnum.NAKED_SINGLE)) {
-            this.hint = new Hint(nakedSingle);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has a naked pair and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a naked pair
-     */
-    private setNakedPair(cells: Cell[][]):boolean {
-        let nakedPair: Strategy = new Strategy(this.board, cells);
-        if (nakedPair.setStrategyType(StrategyEnum.NAKED_PAIR)) {
-            this.hint = new Hint(nakedPair);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has a naked triplet and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a naked triplet
-     */
-    private setNakedTriplet(cells: Cell[][]):boolean {
-        let nakedTriplet: Strategy = new Strategy(this.board, cells);
-        if (nakedTriplet.setStrategyType(StrategyEnum.NAKED_TRIPLET)) {
-            this.hint = new Hint(nakedTriplet);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has a naked quadruplet and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a naked quadruplet
-     */
-    private setNakedQuadruplet(cells: Cell[][]):boolean {
-        let nakedQuadruplet: Strategy = new Strategy(this.board, cells);
-        if (nakedQuadruplet.setStrategyType(StrategyEnum.NAKED_QUADRUPLET)) {
-            this.hint = new Hint(nakedQuadruplet);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has a naked quintuplet and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a naked quintuplet
-     */
-    private setNakedQuintuplet(cells: Cell[][]):boolean {
-        let nakedQuintuplet: Strategy = new Strategy(this.board, cells);
-        if (nakedQuintuplet.setStrategyType(StrategyEnum.NAKED_QUINTUPLET)) {
-            this.hint = new Hint(nakedQuintuplet);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has a naked sextuplet and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a naked sextuplet
-     */
-    private setNakedSextuplet(cells: Cell[][]):boolean {
-        let nakedSextuplet: Strategy = new Strategy(this.board, cells);
-        if (nakedSextuplet.setStrategyType(StrategyEnum.NAKED_SEXTUPLET)) {
-            this.hint = new Hint(nakedSextuplet);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has a naked septuplet and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a naked septuplet
-     */
-    private setNakedSeptuplet(cells: Cell[][]):boolean {
-        let nakedSeptuplet: Strategy = new Strategy(this.board, cells);
-        if (nakedSeptuplet.setStrategyType(StrategyEnum.NAKED_SEPTUPLET)) {
-            this.hint = new Hint(nakedSeptuplet);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has a naked octuplet and sets hint, otherwise returns false
-     * @param cells - empty cells
-     * @returns true if contains a naked octuplet
-     */
-    private setNakedOctuplet(cells: Cell[][]):boolean {
-        let nakedOctuplet: Strategy = new Strategy(this.board, cells);
-        if (nakedOctuplet.setStrategyType(StrategyEnum.NAKED_OCTUPLET)) {
-            this.hint = new Hint(nakedOctuplet);
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -136,7 +136,7 @@ export class Solver{
      */
     private setHiddenSingle(cells: Cell[][]):boolean {
         let hiddenSingle: Strategy = new Strategy(this.board, cells);
-        if (hiddenSingle.isHiddenSingle()) {
+        if (hiddenSingle.setStrategyType(StrategyEnum.HIDDEN_SINGLE)) {
             this.hint = new HiddenSingleHint(hiddenSingle);
             return true;
         }
@@ -150,7 +150,7 @@ export class Solver{
      */
     private setNakedSingle(cells: Cell[][]):boolean {
         let nakedSingle: Strategy = new Strategy(this.board, cells);
-        if (nakedSingle.isNakedSingle()) {
+        if (nakedSingle.setStrategyType(StrategyEnum.NAKED_SINGLE)) {
             this.hint = new NakedSingleHint(nakedSingle);
             return true;
         }
@@ -164,7 +164,7 @@ export class Solver{
      */
     private setNakedPair(cells: Cell[][]):boolean {
         let nakedPair: Strategy = new Strategy(this.board, cells);
-        if (nakedPair.isNakedPair()) {
+        if (nakedPair.setStrategyType(StrategyEnum.NAKED_PAIR)) {
             this.hint = new NakedPairHint(nakedPair);
             return true;
         }
@@ -178,7 +178,7 @@ export class Solver{
      */
     private setNakedTriplet(cells: Cell[][]):boolean {
         let nakedTriplet: Strategy = new Strategy(this.board, cells);
-        if (nakedTriplet.isNakedTriplet()) {
+        if (nakedTriplet.setStrategyType(StrategyEnum.NAKED_TRIPLET)) {
             this.hint = new NakedTripletHint(nakedTriplet);
             return true;
         }
@@ -192,7 +192,7 @@ export class Solver{
      */
     private setNakedQuadruplet(cells: Cell[][]):boolean {
         let nakedQuadruplet: Strategy = new Strategy(this.board, cells);
-        if (nakedQuadruplet.isNakedQuadruplet()) {
+        if (nakedQuadruplet.setStrategyType(StrategyEnum.NAKED_QUADRUPLET)) {
             this.hint = new NakedQuadrupletHint(nakedQuadruplet);
             return true;
         }
@@ -206,7 +206,7 @@ export class Solver{
      */
     private setNakedQuintuplet(cells: Cell[][]):boolean {
         let nakedQuintuplet: Strategy = new Strategy(this.board, cells);
-        if (nakedQuintuplet.isNakedQuintuplet()) {
+        if (nakedQuintuplet.setStrategyType(StrategyEnum.NAKED_QUINTUPLET)) {
             this.hint = new NakedQuintupletHint(nakedQuintuplet);
             return true;
         }
@@ -220,7 +220,7 @@ export class Solver{
      */
     private setNakedSextuplet(cells: Cell[][]):boolean {
         let nakedSextuplet: Strategy = new Strategy(this.board, cells);
-        if (nakedSextuplet.isNakedSextuplet()) {
+        if (nakedSextuplet.setStrategyType(StrategyEnum.NAKED_SEXTUPLET)) {
             this.hint = new NakedSextupletHint(nakedSextuplet);
             return true;
         }
@@ -234,7 +234,7 @@ export class Solver{
      */
     private setNakedSeptuplet(cells: Cell[][]):boolean {
         let nakedSeptuplet: Strategy = new Strategy(this.board, cells);
-        if (nakedSeptuplet.isNakedSeptuplet()) {
+        if (nakedSeptuplet.setStrategyType(StrategyEnum.NAKED_SEPTUPLET)) {
             this.hint = new NakedSeptupletHint(nakedSeptuplet);
             return true;
         }
@@ -248,7 +248,7 @@ export class Solver{
      */
     private setNakedOctuplet(cells: Cell[][]):boolean {
         let nakedOctuplet: Strategy = new Strategy(this.board, cells);
-        if (nakedOctuplet.isNakedOctuplet()) {
+        if (nakedOctuplet.setStrategyType(StrategyEnum.NAKED_OCTUPLET)) {
             this.hint = new NakedOctupletHint(nakedOctuplet);
             return true;
         }

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -130,46 +130,17 @@ export class Solver{
     }
 
     /**
-     * If given Strategy is a hidden single it sets the hint to it and returns true
-     * @param hiddenSingle - Strategy
-     * @returns true if given Strategy is a hidden single
-     */
-    private setHiddenSingleHint(hiddenSingle: Strategy):boolean {
-        if (hiddenSingle.isHiddenSingle()) {
-            this.hint = new HiddenSingleHint(hiddenSingle);
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Returns true if puzzle has given strategy (in a row, column, or box) and sets hint, otherwise returns false
-     * @param strategy - strategy to check for
-     * @param cells - cells to create strategy with
-     * @returns true if contains given strategy
-     */
-    private setGroupStrategy(strategy: StrategyEnum, cells: Cell[][]):boolean {
-        // Checks every group of rows, columns, and boxes for given strategy
-        for (let group:number = 0; group < SudokuEnum.ROW_LENGTH; group++) {
-            let row: Strategy = Strategy.getRowStrategy(this.board, cells, group);
-            let column: Strategy = Strategy.getColumnStrategy(this.board, cells, group);
-            let box: Strategy = Strategy.getBoxStrategy(this.board, cells, group);
-            if (strategy === StrategyEnum.HIDDEN_SINGLE) {
-                if (this.setHiddenSingleHint(row) || this.setHiddenSingleHint(column) || this.setHiddenSingleHint(box)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
      * Returns true if puzzle has a hidden single and sets hint, otherwise returns false
      * @param cells - empty cells
      * @returns true if contains a hidden single
      */
     private setHiddenSingle(cells: Cell[][]):boolean {
-        return this.setGroupStrategy(StrategyEnum.HIDDEN_SINGLE, cells);
+        let hiddenSingle: Strategy = new Strategy(this.board, cells);
+        if (hiddenSingle.isHiddenSingle()) {
+            this.hint = new HiddenSingleHint(hiddenSingle);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/Generator/Strategy.ts
+++ b/Generator/Strategy.ts
@@ -74,6 +74,43 @@ export class Strategy{
     }
 
     /**
+     * Checks if strategy is a given strategy type and if so sets values to place, notes to remove
+     * @returns true if strategy is strategyType
+     */
+    public setStrategyType(strategyType: StrategyEnum):boolean {
+        if (strategyType === StrategyEnum.NAKED_SINGLE) {
+            return this.isNakedSet(TupleEnum.SINGLE);
+        }
+        else if (strategyType === StrategyEnum.NAKED_PAIR) {
+            return this.isNakedSet(TupleEnum.PAIR);
+        }
+        else if (strategyType === StrategyEnum.NAKED_TRIPLET) {
+            return this.isNakedSet(TupleEnum.TRIPLET);
+        }
+        else if (strategyType === StrategyEnum.NAKED_QUADRUPLET) {
+            return this.isNakedSet(TupleEnum.QUADRUPLET);
+        }
+        else if (strategyType === StrategyEnum.NAKED_QUINTUPLET) {
+            return this.isNakedSet(TupleEnum.QUINTUPLET);
+        }
+        else if (strategyType === StrategyEnum.NAKED_SEXTUPLET) {
+            return this.isNakedSet(TupleEnum.SEXTUPLET);
+        }
+        else if (strategyType === StrategyEnum.NAKED_SEPTUPLET) {
+            return this.isNakedSet(TupleEnum.SEPTUPLET);
+        }
+        else if (strategyType === StrategyEnum.NAKED_OCTUPLET) {
+            return this.isNakedSet(TupleEnum.OCTUPLET);
+        }
+        else if (strategyType === StrategyEnum.HIDDEN_SINGLE) {
+            return this.isHiddenSet(TupleEnum.SINGLE);
+        }
+        else {
+            return false;
+        }
+    }
+
+    /**
      * Gets cells that "cause" strategy to be applicable
      * @returns cells
      * @throws {@link CustomError}
@@ -206,7 +243,7 @@ export class Strategy{
      * @param tuple - e.g. could be single or pair for naked single or naked pair respectively
      * @returns true if strategy is a naked tuple
      */
-    public isNakedSet(tuple: TupleEnum):boolean {
+    private isNakedSet(tuple: TupleEnum):boolean {
         // Checks if tuple exists by getting all cells (with note size <= tuple) in each group and trying to build tuple
         // Checks every subset (combination) of cells in each group (row/column/box)
         let subsets:Group[] = Group.getSubset(tuple);
@@ -325,19 +362,11 @@ export class Strategy{
     }
 
     /**
-     * Checks if strategy is a naked single and if so adds values that can be placed
-     * @returns true if strategy is a naked single
-     */
-    public isNakedSingle():boolean {
-        return this.isNakedSet(TupleEnum.SINGLE);
-    }
-
-    /**
      * Checks if strategy is a hidden set of given tuple and if so adds notes to remove
      * @param tuple - e.g. could be single or pair for hidden single or hidden pair respectively
      * @returns true if strategy is a hidden tuple
      */
-    public isHiddenSet(tuple: TupleEnum):boolean {
+    private isHiddenSet(tuple: TupleEnum):boolean {
         // Checks if tuple exists by getting all cells in each group and trying to build hidden tuple
         // Checks every subset (combination) of cells in each group (row/column/box)
         let subsets:Group[] = Group.getSubset(tuple);
@@ -398,70 +427,6 @@ export class Strategy{
             }
         }
         return this.identified;
-    }
-
-    /**
-     * Checks if strategy is a hidden single and if so adds values that can be placed
-     * @returns true if strategy is a hidden single
-     */
-    public isHiddenSingle():boolean {
-        return this.isHiddenSet(TupleEnum.SINGLE);
-    }
-
-    /**
-     * Checks if strategy is a naked pair and if so adds notes that can be removed
-     * @returns true if strategy is a naked pair
-     */
-    public isNakedPair():boolean {
-        return this.isNakedSet(TupleEnum.PAIR);
-    }
-
-    /**
-     * Checks if strategy is a naked triplet and if so adds notes that can be removed
-     * @returns true if strategy is a naked triplet
-     */
-    public isNakedTriplet():boolean {
-        return this.isNakedSet(TupleEnum.TRIPLET);
-    }
-
-    /**
-     * Checks if strategy is a naked quadruplet and if so adds notes that can be removed
-     * @returns true if strategy is a naked quadruplet
-     */
-    public isNakedQuadruplet():boolean {
-        return this.isNakedSet(TupleEnum.QUADRUPLET);
-    }
-
-    /**
-     * Checks if strategy is a naked quintuplet and if so adds notes that can be removed
-     * @returns true if strategy is a naked quintuplet
-     */
-    public isNakedQuintuplet():boolean {
-        return this.isNakedSet(TupleEnum.QUINTUPLET);
-    }
-
-    /**
-     * Checks if strategy is a naked sextuplet and if so adds notes that can be removed
-     * @returns true if strategy is a naked sextuplet
-     */
-    public isNakedSextuplet():boolean {
-        return this.isNakedSet(TupleEnum.SEXTUPLET);
-    }
-
-    /**
-     * Checks if strategy is a naked septuplet and if so adds notes that can be removed
-     * @returns true if strategy is a naked septuplet
-     */
-    public isNakedSeptuplet():boolean {
-        return this.isNakedSet(TupleEnum.SEPTUPLET);
-    }
-
-    /**
-     * Checks if strategy is a naked octuplet and if so adds notes that can be removed
-     * @returns true if strategy is a naked octuplet
-     */
-    public isNakedOctuplet():boolean {
-        return this.isNakedSet(TupleEnum.OCTUPLET);
     }
 
     /**

--- a/Generator/Strategy.ts
+++ b/Generator/Strategy.ts
@@ -1,6 +1,6 @@
 import { Cell } from "./Cell";
 import { CustomError, CustomErrorEnum } from "./CustomError";
-import { SudokuEnum, StrategyEnum, getCellsInRow, getCellsInColumn, getCellsInBox, GroupEnum, getNextCellInGroup, TupleEnum, getCellsInGroup, getUnionOfSetNotes, inSubset, getCellsSubset } from "./Sudoku"
+import { SudokuEnum, StrategyEnum, getCellsInRow, getCellsInColumn, getCellsInBox, GroupEnum, getNextCellInGroup, TupleEnum, getCellsInGroup, getUnionOfSetNotes, inSubset, getCellsSubset, getCellsInSubset } from "./Sudoku"
 import { Group } from "./Group";
 
 /**
@@ -202,7 +202,7 @@ export class Strategy{
     }
 
     /**
-     * Checks if strategy is a naked set of given tuple and if so adds values that can be placed
+     * Checks if strategy is a naked set of given tuple and if so adds values to be placed and notes to remove
      * @param tuple - e.g. could be single or pair for naked single or naked pair respectively
      * @returns true if strategy is a naked tuple
      */
@@ -223,18 +223,13 @@ export class Strategy{
                     // Stores indexes of the cells that make up the naked set
                     let inNakedSet:Group = getCellsSubset(cells, subsets[j], group);
                     // Stores the cellls that make up the naked set
-                    let nakedSet:Cell[] = new Array();
-                    for (let k:number = 0; k < SudokuEnum.ROW_LENGTH; k++) {
-                        if (inNakedSet.contains(k)) {
-                            nakedSet.push(cells[k]);
-                        }
-                    }
+                    let nakedSet:Cell[] = getCellsInSubset(cells, inNakedSet);
                     // If naked set is correct size (i.e. every element in subset was in cells)
                     if (nakedSet.length === tuple) {
-                        // Calculates alll notes in naked set
+                        // Calculates all notes in naked set
                         let nakedSetCandidates:Group = getUnionOfSetNotes(nakedSet);
-                        // If naked set has correct number of notes
-                        if (nakedSetCandidates.getSize() <= tuple) {
+                        // Is naked set if it has correct number of notes
+                        if (nakedSetCandidates.getSize() === tuple) {
                             // If it is a naked single places value
                             if (tuple === TupleEnum.SINGLE) {
                                 let row:number = nakedSet[0].getRow();
@@ -338,58 +333,79 @@ export class Strategy{
     }
 
     /**
-     * Checks if strategy is a hidden single and if so adds values that can be placed
-     * @returns true if strategy is a hidden single
+     * Checks if strategy is a hidden set of given tuple and if so adds notes to remove
+     * @param tuple - e.g. could be single or pair for hidden single or hidden pair respectively
+     * @returns true if strategy is a hidden tuple
      */
-    public isHiddenSingle():boolean {
-        // stores candidates found in the cells
-        let found:Group = new Group(false);
-        // stores possible hidden single for each candidate at their corresponding index
-        // initialized to null, set to cell with hidden single, reset to null if multiple cells with note found
-        let single:Cell[] = new Array(SudokuEnum.ROW_LENGTH).fill(null);
-        // Stores total number of notes in cells in the group to be used to calculate the difficulty
-        let noteCount:number = 0;
-
-        let notes:Group;
-        let row:number, column:number;
-        // Checks notes of every empty cell in group (row/column/box) provided
-        for (let i:number = 0; i < this.cells.length; i++) {
-            for (let j:number = 0; j < this.cells[i].length; j++) {
-                // Checks each note of the cell
-                notes = this.cells[i][j].getNotes();
-                noteCount += notes.getSize();
-                for (let note:number = 0; note < SudokuEnum.ROW_LENGTH; note++) {
-                    if (notes.contains(note)) {
-                        // Add cell to hidden single Cell if this note not found before, otherwise set to null
-                        if (found.insert(note)) {
-                            row = this.cells[i][j].getRow();
-                            column = this.cells[i][j].getColumn();
-                            single[note] = new Cell(row, column, (note+1).toString());
+    public isHiddenSet(tuple: TupleEnum):boolean {
+        // Checks if tuple exists by getting all cells in each group and trying to build hidden tuple
+        // Checks every subset (combination) of cells in each group (row/column/box)
+        let subsets:Group[] = Group.getSubset(tuple);
+        for (let group:GroupEnum = 0; group < GroupEnum.COUNT; group++) {
+            for (let i:number = 0; i < SudokuEnum.ROW_LENGTH; i++) {
+                // Contains cells in the same row, column, or box
+                let cells: Cell[] = getCellsInGroup(this.cells, group, i);
+                // Tries to build a hidden set of size tuple for each possible size tuple subset of candidates
+                // Is hidden single iff the number of candidates that don't exist outside of the hidden tuple
+                // is equal to the tuple (e.g. hidden pair if there are two numbers only in the pair in the row)
+                for (let j:number = 0; j < subsets.length; j++) {
+                    // Stores indexes of the cells that make up the hidden set
+                    let inHiddenSet:Group = getCellsSubset(cells, subsets[j], group);
+                    // Stores the cells that make up the hidden set
+                    let hiddenSet:Cell[] = getCellsInSubset(cells, inHiddenSet);
+                    // If hidden set is correct size (i.e. every element in subset was in cells)
+                    if (hiddenSet.length === tuple) {
+                        // Stores all of the cells in the hidden sets group (except the hidden set itself and non empty cells)
+                        let notHiddenSet:Cell[] = new Array();
+                        for (let k:number = 0; k < cells.length; k++) {
+                            if (!inHiddenSet.contains(k) && cells[k].isEmpty()) {
+                                notHiddenSet.push(cells[k]);
+                            }
                         }
-                        else {
-                            single[note] = null;
+                        // Calculates notes that aren't in the hidden set
+                        let notHiddenSetCandidates:Group = getUnionOfSetNotes(notHiddenSet);
+                        // Calculates notes that are in the hidden set
+                        let hiddenSetCandidates:Group = getUnionOfSetNotes(hiddenSet);
+                        // Is hidden set if correct number of candidates don't exist outside of the hidden set
+                        if ((hiddenSetCandidates.getSize() - (hiddenSetCandidates.intersection(notHiddenSetCandidates)).getSize()) === tuple) {
+                            // Remove candidates that aren't part of the hidden set from the hidden sets notes
+                            for (let k:number = 0; k < tuple; k++) {
+                                if ((hiddenSet[k].getNotes().intersection(notHiddenSetCandidates)).getSize() > 0) {
+                                    let notes:Group = new Group(false, hiddenSet[k].getRow(), hiddenSet[k].getColumn());
+                                    notes.insert(notHiddenSetCandidates);
+                                    this.notes.push(notes);
+                                    this.identified = true;
+                                }
+                            }
+                            // If notes were found you can remove as part of the hidden single then strategy identified
+                            if (this.identified) {
+                                // Calculate ratio of number of notes to possible number (more notes to obscure hidden set = higher difficulty)
+                                let noteCount:number = 0;
+                                for (let k:number = 0; k < tuple; k++) {
+                                    noteCount += (hiddenSet[k].getNotes()).getSize();
+                                }
+                                let noteRatio:number = noteCount / (SudokuEnum.ROW_LENGTH * SudokuEnum.ROW_LENGTH);
+                                if (tuple === TupleEnum.SINGLE) {
+                                    this.strategyType = StrategyEnum.HIDDEN_SINGLE;
+                                    this.difficulty = DifficultyLowerBounds.HIDDEN_SINGLE;
+                                    this.difficulty += Math.ceil(noteRatio * (DifficultyUpperBounds.HIDDEN_SINGLE - DifficultyLowerBounds.HIDDEN_SINGLE));
+                                }
+                                return this.identified;
+                            }
                         }
                     }
                 }
             }
         }
+        return this.identified;
+    }
 
-        // Checks if a hidden single was found
-        for (let i:number = 0; i < SudokuEnum.ROW_LENGTH; i++) {
-            if (found.contains(i) && single[i] !== null) {
-                // Identify strategy, calculate difficulty, and return that it is a hidden single
-                this.values.push(single[i]);
-                this.strategyType = StrategyEnum.HIDDEN_SINGLE;
-                this.identified = true;
-                // Calculate ratio of noteCount to total possible note count in a group
-                let noteRatio:number = noteCount / (SudokuEnum.ROW_LENGTH * SudokuEnum.ROW_LENGTH);
-                // Set difficulty to hidden single lower bound adjusted upwards based on noteRatio
-                this.difficulty = DifficultyLowerBounds.HIDDEN_SINGLE;
-                this.difficulty += Math.ceil(noteRatio) * (DifficultyUpperBounds.HIDDEN_SINGLE - DifficultyLowerBounds.HIDDEN_SINGLE);
-                return true;
-            }
-        }
-        return false;
+    /**
+     * Checks if strategy is a hidden single and if so adds values that can be placed
+     * @returns true if strategy is a hidden single
+     */
+    public isHiddenSingle():boolean {
+        return this.isHiddenSet(TupleEnum.SINGLE);
     }
 
     /**

--- a/Generator/Sudoku.ts
+++ b/Generator/Sudoku.ts
@@ -264,7 +264,7 @@ export function getNextCellInBox(cells: Cell[][], cell: Cell, index?: number):Ce
     for (let i:number = 0; i < box.length; i++) {
         for (let j:number = 0; j < box[i].length; j++) {
             // Return first cell if cell is null otherwise returns next cell in box after cell
-            if (cell === null || (i > cell.getRow()) || ((i === cell.getRow()) && (j > cell.getColumn()))) {
+            if (cell === null || (i > cell.getRow()) || ((i === cell.getRow()) && (box[i][j].getColumn() > cell.getColumn()))) {
                 return box[i][j];
             }
         }
@@ -385,4 +385,20 @@ export function getCellsSubset(cells: Cell[], subset: Group, group: GroupEnum):G
         }
     }
     return cellsSubset;
+}
+
+/**
+ * Returns an array of cells in the given subset
+ * @param cells - cells array
+ * @param subset - subset of cells
+ * @returns array of cells representing the given subset of the given cells array
+ */
+export function getCellsInSubset(cells: Cell[], subset: Group):Cell[] {
+    let cellsInSubset:Cell[] = new Array();
+    for (let i:number = 0; i < SudokuEnum.ROW_LENGTH; i++) {
+        if (subset.contains(i)) {
+            cellsInSubset.push(cells[i]);
+        }
+    }
+    return cellsInSubset;
 }

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -137,10 +137,10 @@ describe("solve Boards", () => {
         expect(singleNakedSingle.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
         for (let i:number = 0; i < StrategyEnum.COUNT; i++) {
             if (i === StrategyEnum.NAKED_SINGLE) {
-                expect(singleNakedSingle.getStrategies()[i]).toBeTruthy;
+                expect(singleNakedSingle.getStrategies()[i]).toBeTruthy();
             }
             else {
-                expect(singleNakedSingle.getStrategies()[i]).toBeFalsy;
+                expect(singleNakedSingle.getStrategies()[i]).toBeFalsy();
             }
         }
     });

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -145,14 +145,6 @@ describe("solve Boards", () => {
         }
     });
 
-    it('should solve single naked single using hidden single', () => {
-        let algorithm:StrategyEnum[] = new Array();
-        algorithm.push(StrategyEnum.HIDDEN_SINGLE);
-        let board:Board = new Board(TestBoards.SINGLE_NAKED_SINGLE, algorithm);
-        expect(board.getSolutionString()).toBe(TestBoards.SINGLE_NAKED_SINGLE_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.HIDDEN_SINGLE);
-    });
-
     it('should solve naked singles only board', () => {
         expect(onlyNakedSingles.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
         expect(onlyNakedSingles.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);

--- a/Generator/tests/unit/Cell.test.ts
+++ b/Generator/tests/unit/Cell.test.ts
@@ -23,18 +23,18 @@ describe("create Cell object", () => {
     it('should remove notes', () => {
         let obj:Cell = new Cell(0, 0);
 
-        expect(obj.hasNote("1")).toBeTruthy;
+        expect(obj.hasNote("1")).toBeTruthy();
         obj.removeNote("1");
-        expect(obj.hasNote("1")).toBeFalsy;
+        expect(obj.hasNote("1")).toBeFalsy();
 
-        expect(obj.hasNote("2")).toBeTruthy;
-        expect(obj.hasNote("3")).toBeTruthy;
+        expect(obj.hasNote("2")).toBeTruthy();
+        expect(obj.hasNote("3")).toBeTruthy();
         let notes:Group = new Group(false);
         notes.insert("2");
         notes.insert("3");
         obj.removeNotes(notes);
-        expect(obj.hasNote("2")).toBeFalsy;
-        expect(obj.hasNote("3")).toBeFalsy;
+        expect(obj.hasNote("2")).toBeFalsy();
+        expect(obj.hasNote("3")).toBeFalsy();
     });
     it('should initialize box', () => {
         let a:Cell = new Cell(1, 1);

--- a/Generator/tests/unit/Group.test.ts
+++ b/Generator/tests/unit/Group.test.ts
@@ -8,45 +8,45 @@ describe("create Group object", () => {
         let obj:Group = new Group(false);
         expect(obj.getSize()).toBe(0);
 
-        expect(obj.contains("1")).toBeFalsy;
-        expect(obj.contains(0)).toBeFalsy;
+        expect(obj.contains("1")).toBeFalsy();
+        expect(obj.contains(0)).toBeFalsy();
 
-        expect(obj.insert("1")).toBeTruthy;
+        expect(obj.insert("1")).toBeTruthy();
         expect(obj.getSize()).toBe(1);
-        expect(obj.insert(0)).toBeFalsy;
+        expect(obj.insert(0)).toBeFalsy();
         expect(obj.getSize()).toBe(1);
 
-        expect(obj.contains("1")).toBeTruthy;
-        expect(obj.contains(0)).toBeTruthy;
+        expect(obj.contains("1")).toBeTruthy();
+        expect(obj.contains(0)).toBeTruthy();
 
-        expect(obj.contains("3")).toBeFalsy;
-        expect(obj.insert(2)).toBeTruthy;
-        expect(obj.contains("3")).toBeTruthy;
+        expect(obj.contains("3")).toBeFalsy();
+        expect(obj.insert(2)).toBeTruthy();
+        expect(obj.contains("3")).toBeTruthy();
 
         let i:Group = new Group(true);
-        expect(obj.insert(i)).toBeTruthy;
+        expect(obj.insert(i)).toBeTruthy();
         expect(obj.getSize()).toBe(9);
     });
     it('should remove some candidates', () => {
         let obj:Group = new Group(true);
         expect(obj.getSize()).toBe(9);
 
-        expect(obj.contains("1")).toBeTruthy;
-        expect(obj.remove("1")).toBeTruthy;
+        expect(obj.contains("1")).toBeTruthy();
+        expect(obj.remove("1")).toBeTruthy();
         expect(obj.getSize()).toBe(8);
-        expect(obj.contains("1")).toBeFalsy;
-        expect(obj.remove("1")).toBeFalsy;
+        expect(obj.contains("1")).toBeFalsy();
+        expect(obj.remove("1")).toBeFalsy();
         expect(obj.getSize()).toBe(8);
 
-        expect(obj.remove(3)).toBeTruthy;
-        expect(obj.contains(3)).toBeFalsy;
+        expect(obj.remove(3)).toBeTruthy();
+        expect(obj.contains(3)).toBeFalsy();
 
         let r:Group = new Group(false);
-        expect(obj.remove(r)).toBeFalsy;
+        expect(obj.remove(r)).toBeFalsy();
         r.insert("1");
         r.insert(6);
         r.insert(7);
-        expect(obj.remove(r)).toBeTruthy;
+        expect(obj.remove(r)).toBeTruthy();
         expect(obj.getSize()).toBe(5);
     });
     it('should be equal then unequal', () => {
@@ -65,13 +65,13 @@ describe("create Group object", () => {
         d.insert(a);
         d.insert(4);
         
-        expect(a.equals(b)).toBeTruthy;
-        expect(a.equals(a.clone())).toBeTruthy;
-        expect(d.equals(Group.union([a, c]))).toBeTruthy;
+        expect(a.equals(b)).toBeTruthy();
+        expect(a.equals(a.clone())).toBeTruthy();
+        expect(d.equals(Group.union([a, c]))).toBeTruthy();
 
         a.insert(7);
 
-        expect(b.equals(a)).toBeFalsy;
+        expect(b.equals(a)).toBeFalsy();
     });
     it('should return subsets', () => {
         expect((Group.getSubset(1)).length).toBe(SudokuEnum.ROW_LENGTH);

--- a/Generator/tests/unit/Strategy.test.ts
+++ b/Generator/tests/unit/Strategy.test.ts
@@ -3,7 +3,7 @@ import { Cell } from '../../Cell';
 import { CustomError, CustomErrorEnum } from '../../CustomError';
 import { getBlankCellBoard, getError, getRowTuplet, removeNotesFromEach, removeTupleNotes } from '../testResources';
 import { Group } from '../../Group';
-import { SudokuEnum, TupleEnum } from '../../Sudoku';
+import { StrategyEnum, SudokuEnum, TupleEnum } from '../../Sudoku';
 
 describe("create naked single", () => {
     it('should throw strategy not identified error', async () => {
@@ -14,21 +14,17 @@ describe("create naked single", () => {
         expect(error).toHaveProperty('Error_Message', CustomErrorEnum.STRATEGY_NOT_IDENTIFIED);
     });
     it('should not be a naked single', () => {
-        let cells:Cell[][] = new Array();
-        let cell:Cell = new Cell(0, 0);
-        cells.push([cell]);
-        let strategy:Strategy = new Strategy(cells, cells);
-        expect(strategy.isNakedSingle).toBeFalsy;
+        let board:Cell[][] = getBlankCellBoard();
+        let strategy:Strategy = new Strategy(board, board);
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_SINGLE)).toBeFalsy;
     });
     it('should be a naked single', () => {
-        let cells:Cell[][] = new Array();
-        let cell:Cell = new Cell(0, 0);
-        for (let i:number = 1; i < 9; i++) {
-            cell.removeNote(i.toString());
+        let board:Cell[][] = getBlankCellBoard();
+        for (let i:number = 1; i < SudokuEnum.COLUMN_LENGTH; i++) {
+            (board[0][0]).removeNote(i.toString());
         }
-        cells.push([cell]);
-        let strategy:Strategy = new Strategy(cells, cells);
-        expect(strategy.isNakedSingle()).toBeTruthy;
+        let strategy:Strategy = new Strategy(board, board);
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_SINGLE)).toBeTruthy;
         expect(strategy.getValuesToPlace()[0].getValue()).toBe("9");
     });
 });
@@ -46,7 +42,7 @@ describe("create hidden single", () => {
             board[0][i].removeNote("6");
         }
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.isHiddenSingle()).toBeFalsy;
+        expect(strategy.setStrategyType(StrategyEnum.HIDDEN_SINGLE)).toBeFalsy;
     });
     it ('should be a hidden single', () => {
         let board:Cell[][] = getBlankCellBoard();
@@ -54,7 +50,7 @@ describe("create hidden single", () => {
             board[0][i].removeNote("9");
         }
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.isHiddenSingle()).toBeTruthy;
+        expect(strategy.setStrategyType(StrategyEnum.HIDDEN_SINGLE)).toBeTruthy;
         expect((strategy.getNotesToRemove())[0].getSize()).toBe(SudokuEnum.ROW_LENGTH - 1);
     });
 });
@@ -76,7 +72,7 @@ describe("create naked pair", () => {
 
         // Test that it isn't a naked pair
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.isNakedPair()).toBeFalsy;
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_PAIR)).toBeFalsy;
     });
     it("should be a naked pair", () => {
         // Create board
@@ -92,7 +88,7 @@ describe("create naked pair", () => {
 
         // Test that is naked pair and can remove notes from every cell in shared row and box except naked pair themself
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.isNakedPair()).toBeTruthy;
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_PAIR)).toBeTruthy;
         expect(strategy.getNotesToRemove().length).toBe(13);
     });
 });
@@ -112,7 +108,7 @@ describe("create naked triplet", () => {
 
         // Test that is naked triplet and can remove notes from every cell in shared row and box except naked triplet themself
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.isNakedTriplet()).toBeTruthy;
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_TRIPLET)).toBeTruthy;
         expect(strategy.getNotesToRemove().length).toBe(12);
     });
 });
@@ -134,7 +130,22 @@ describe("create naked quadruplet through octuplet", () => {
 
             // Test that is naked set and can remove notes from every cell in shared row and box except naked tuplet themself
             let strategy:Strategy = new Strategy(board, board);
-            expect(strategy.isNakedSet(tuple)).toBeTruthy;
+            //expect(strategy.setStrategyType()).toBeTruthy;
+            if (tuple === TupleEnum.QUADRUPLET) {
+                expect(strategy.setStrategyType(StrategyEnum.NAKED_QUADRUPLET));
+            }
+            else if (tuple === TupleEnum.QUINTUPLET) {
+                expect(strategy.setStrategyType(StrategyEnum.NAKED_QUINTUPLET));
+            }
+            else if (tuple === TupleEnum.SEXTUPLET) {
+                expect(strategy.setStrategyType(StrategyEnum.NAKED_SEXTUPLET));
+            }
+            else if (tuple === TupleEnum.SEPTUPLET) {
+                expect(strategy.setStrategyType(StrategyEnum.NAKED_SEPTUPLET));
+            }
+            else if (tuple === TupleEnum.OCTUPLET) {
+                expect(strategy.setStrategyType(StrategyEnum.NAKED_OCTUPLET));
+            }
             expect(strategy.getNotesToRemove().length).toBe(SudokuEnum.ROW_LENGTH - tuple);
         }
     });

--- a/Generator/tests/unit/Strategy.test.ts
+++ b/Generator/tests/unit/Strategy.test.ts
@@ -35,35 +35,27 @@ describe("create naked single", () => {
 
 describe("create hidden single", () => {
     it('should not be a hidden single', () => {
-        let cells:Cell[][] = new Array();
-        cells.push(new Array());
-        for (let i:number = 0; i < 9; i++) {
-            cells[0].push(new Cell(0, 0));
-        }
-        cells[0][0].removeNote("3");
-        cells[0][4].removeNote("3");
-        cells[0][2].removeNote("5");
+        let board:Cell[][] = getBlankCellBoard();
+        board[0][0].removeNote("3");
+        board[0][4].removeNote("3");
+        board[0][2].removeNote("5");
         for (let i:number = 0; i < 7; i++) {
-            cells[0][i].removeNote("7");
+            board[0][i].removeNote("7");
         }
         for (let i:number = 1; i < 8; i++) {
-            cells[0][i].removeNote("6");
+            board[0][i].removeNote("6");
         }
-        let strategy:Strategy = new Strategy(cells, cells);
+        let strategy:Strategy = new Strategy(board, board);
         expect(strategy.isHiddenSingle()).toBeFalsy;
     });
     it ('should be a hidden single', () => {
-        let cells:Cell[][] = new Array();
-        cells.push(new Array());
-        for (let i:number = 0; i < 9; i++) {
-            cells[0].push(new Cell(0, 0));
-        }
+        let board:Cell[][] = getBlankCellBoard();
         for (let i:number = 0; i < 8; i++) {
-            cells[0][i].removeNote("9");
+            board[0][i].removeNote("9");
         }
-        let strategy:Strategy = new Strategy(cells, cells);
+        let strategy:Strategy = new Strategy(board, board);
         expect(strategy.isHiddenSingle()).toBeTruthy;
-        expect(strategy.getValuesToPlace()[0].getValue()).toBe("9");
+        expect((strategy.getNotesToRemove())[0].getSize()).toBe(SudokuEnum.ROW_LENGTH - 1);
     });
 });
 

--- a/Generator/tests/unit/Strategy.test.ts
+++ b/Generator/tests/unit/Strategy.test.ts
@@ -16,7 +16,7 @@ describe("create naked single", () => {
     it('should not be a naked single', () => {
         let board:Cell[][] = getBlankCellBoard();
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.setStrategyType(StrategyEnum.NAKED_SINGLE)).toBeFalsy;
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_SINGLE)).toBeFalsy();
     });
     it('should be a naked single', () => {
         let board:Cell[][] = getBlankCellBoard();
@@ -24,7 +24,7 @@ describe("create naked single", () => {
             (board[0][0]).removeNote(i.toString());
         }
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.setStrategyType(StrategyEnum.NAKED_SINGLE)).toBeTruthy;
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_SINGLE)).toBeTruthy();
         expect(strategy.getValuesToPlace()[0].getValue()).toBe("9");
     });
 });
@@ -42,7 +42,7 @@ describe("create hidden single", () => {
             board[0][i].removeNote("6");
         }
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.setStrategyType(StrategyEnum.HIDDEN_SINGLE)).toBeFalsy;
+        expect(strategy.setStrategyType(StrategyEnum.HIDDEN_SINGLE)).toBeFalsy();
     });
     it ('should be a hidden single', () => {
         let board:Cell[][] = getBlankCellBoard();
@@ -50,7 +50,7 @@ describe("create hidden single", () => {
             board[0][i].removeNote("9");
         }
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.setStrategyType(StrategyEnum.HIDDEN_SINGLE)).toBeTruthy;
+        expect(strategy.setStrategyType(StrategyEnum.HIDDEN_SINGLE)).toBeTruthy();
         expect((strategy.getNotesToRemove())[0].getSize()).toBe(SudokuEnum.ROW_LENGTH - 1);
     });
 });
@@ -66,13 +66,12 @@ describe("create naked pair", () => {
         // Remove all but naked pair from one cell and remove naked pair plus one more note from other cell
         // Removing the extra note turns it into a naked single instead of a naked pair
         let notes:Group = new Group(true);
-        removeTupleNotes(TupleEnum.PAIR, notes);
-        removeNotesFromEach(notes, cells);
-        cells[0][1].removeNote("2");
+        removeTupleNotes(TupleEnum.TRIPLET, notes); // removes a triplet of candidates from the notes
+        removeNotesFromEach(notes, cells); // removes notes for all but the triplet of candidates from each cell
 
         // Test that it isn't a naked pair
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.setStrategyType(StrategyEnum.NAKED_PAIR)).toBeFalsy;
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_PAIR)).toBeFalsy();
     });
     it("should be a naked pair", () => {
         // Create board
@@ -88,7 +87,7 @@ describe("create naked pair", () => {
 
         // Test that is naked pair and can remove notes from every cell in shared row and box except naked pair themself
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.setStrategyType(StrategyEnum.NAKED_PAIR)).toBeTruthy;
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_PAIR)).toBeTruthy();
         expect(strategy.getNotesToRemove().length).toBe(13);
     });
 });
@@ -108,7 +107,7 @@ describe("create naked triplet", () => {
 
         // Test that is naked triplet and can remove notes from every cell in shared row and box except naked triplet themself
         let strategy:Strategy = new Strategy(board, board);
-        expect(strategy.setStrategyType(StrategyEnum.NAKED_TRIPLET)).toBeTruthy;
+        expect(strategy.setStrategyType(StrategyEnum.NAKED_TRIPLET)).toBeTruthy();
         expect(strategy.getNotesToRemove().length).toBe(12);
     });
 });
@@ -130,7 +129,7 @@ describe("create naked quadruplet through octuplet", () => {
 
             // Test that is naked set and can remove notes from every cell in shared row and box except naked tuplet themself
             let strategy:Strategy = new Strategy(board, board);
-            //expect(strategy.setStrategyType()).toBeTruthy;
+            //expect(strategy.setStrategyType()).toBeTruthy();
             if (tuple === TupleEnum.QUADRUPLET) {
                 expect(strategy.setStrategyType(StrategyEnum.NAKED_QUADRUPLET));
             }


### PR DESCRIPTION
Refactor the Board and Strategy classes.

Backstory: 

Originally the Solver was expected to generate the groupings of cells that could constitute a strategy and send them to Strategy to see if they are a valid instance of a given Strategy (e.g. pairs of cells for naked pairs). During the generalizing of naked singles, pairs, … to naked sets along with the creation of more complex cell gathering techniques like subsets it no longer made sense to split up the logic between the classes like this and Strategy just used the entire Board for naked sets and generated the groupings of cells for them itself. This simplified the logic of Solver significantly and grouped all of the logic for a Strategy in one function. However, hidden singles, one of the first strategies to be implemented still uses the old way of doing things.

Why Refactor: 

-Aside from consistency their is a pressing reason to refactor. The next thing on the agenda for this project is adding drills. Doing so requires being able to easily call isNakedSet and isHiddenSingle without side effects (like setting Solvers Hint). This is trivial for isNakedSet but hard for isHiddenSingle in its current form. 

-Additionally, this refactor will seek to completely move all Strategy info to the Strategy class. This means instead of creating a Strategy object for each strategy type and calling its isStrategy function Solver will just create one Strategy object which will have a setStrategy function which takes in a StrategyEnum object and returns if it was successfully set to that type. Thus, Solver will just loop over setStrategy via the algorithm in a much simplified setHint. All of this means we can simplify Strategy by moving all but a couple of its functions to private.

-Another major benefit of refactoring isHiddenSingle to work like isNakedSet is that it doing so will result in the creation of isHiddenSet which will work for any hidden tuple.

Future Refactor:

As Strategy class supports more Strategy types it will only get more unwieldy. To deal with Strategy should eventually become a parent class and individual strategies should become subclasses (naked set will be a parent class of naked single, pair, etc). They will also be moved to their own folder. The growing number of helper functions living in Sudoku.ts should also be organized.

Make naked singles work the same as naked pairs.