### PR TITLE
Drills

### DIFF
--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -24,8 +24,8 @@ export class Board{
     private solutionString: string;
     private mostDifficultStrategy: StrategyEnum;
     private strategies: boolean[];
+    private drills: boolean[];
     private difficulty: number;
-    private drills: StrategyEnum[];
     private solver: Solver;
 
     /**
@@ -49,6 +49,7 @@ export class Board{
 
         this.mostDifficultStrategy = -1;
         this.strategies = new Array(StrategyEnum.COUNT).fill(false);
+        this.drills = new Array(StrategyEnum.COUNT).fill(false);
         this.difficulty = 0;
 
         if (algorithm === undefined) {
@@ -115,7 +116,7 @@ export class Board{
      * Get drills
      * @returns drills
      */
-    public getDrills():StrategyEnum[] {
+    public getDrills():boolean[] {
         return this.drills;
     }
 
@@ -126,7 +127,7 @@ export class Board{
         let hints:Hint[] = this.solver.getAllHints();
         this.drills = new Array();
         for (let i:number = 0; i < hints.length; i++) {
-            this.drills.push(hints[i].getStrategyType());
+            this.drills[hints[i].getStrategyType()] = true;
         }
         return;
     }

--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -25,6 +25,7 @@ export class Board{
     private mostDifficultStrategy: StrategyEnum;
     private strategies: boolean[];
     private difficulty: number;
+    private drills: StrategyEnum[];
     private solver: Solver;
 
     /**
@@ -56,6 +57,8 @@ export class Board{
         else {
             this.solver = new Solver(this.board, algorithm);
         }
+
+        this.setDrills();
 
         this.solve();
     }
@@ -106,6 +109,26 @@ export class Board{
      */
     public getDifficulty():number {
         return this.difficulty;
+    }
+
+    /**
+     * Get drills
+     * @returns drills
+     */
+    public getDrills():StrategyEnum[] {
+        return this.drills;
+    }
+
+    /**
+     * Adds a StrategyEnum to drills for each strategy that can be used as the first step in solving this board
+     */
+    private setDrills():void {
+        let hints:Hint[] = this.solver.getAllHints();
+        this.drills = new Array();
+        for (let i:number = 0; i < hints.length; i++) {
+            this.drills.push(hints[i].getStrategyType());
+        }
+        return;
     }
 
     /**

--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -121,13 +121,23 @@ export class Board{
     }
 
     /**
-     * Adds a StrategyEnum to drills for each strategy that can be used as the first step in solving this board
+     * Adds a StrategyEnum to drills for strategies that can be used as the first step in solving this board
+     * If a strategy is added than its prereqs are excluded in order to ensure good examples of strategies are used
+     * For example, if there is a naked pair made up of two naked singles only the naked single will be used as a drill
      */
     private setDrills():void {
         let hints:Hint[] = this.solver.getAllHints();
         this.drills = new Array();
         for (let i:number = 0; i < hints.length; i++) {
             this.drills[hints[i].getStrategyType()] = true;
+        }
+        for (let i:number = 0; i < this.drills.length; i++) {
+            if (this.drills[i]) {
+                let prereqs:StrategyEnum[] = this.getPrereqs(i);
+                for (let j:number = 0; j < prereqs.length; j++) {
+                    this.drills[prereqs[j]] = false;
+                }
+            }
         }
         return;
     }

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -50,9 +50,7 @@ export class Solver{
      * Thrown if board is unsolvable
      */
     public nextStep():Hint {
-        this.emptyCells = new Array();
-        this.initializeCellArray(this.emptyCells, SudokuEnum.COLUMN_LENGTH);
-        this.addEveryEmptyCell(this.emptyCells);
+        this.setEmptyCells();
 
         if (this.isFinished(this.emptyCells)) {
             return null;
@@ -65,6 +63,16 @@ export class Solver{
         }
 
         throw new CustomError(CustomErrorEnum.UNSOLVABLE);
+    }
+
+    /**
+     * Sets emptyCells to be all of the empty cells in the board
+     */
+    private setEmptyCells():void {
+        this.emptyCells = new Array();
+        this.initializeCellArray(this.emptyCells, SudokuEnum.COLUMN_LENGTH);
+        this.addEveryEmptyCell(this.emptyCells);
+        return;
     }
 
     /**

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -41,6 +41,7 @@ export class Solver{
         else {
             this.setNotes(notes);
         }
+        this.setEmptyCells();
         this.solved = false;
         this.algorithm = algorithm;
     }
@@ -52,8 +53,6 @@ export class Solver{
      * Thrown if board is unsolvable
      */
     public nextStep():Hint {
-        this.setEmptyCells();
-
         if (this.isFinished(this.emptyCells)) {
             return null;
         }
@@ -63,6 +62,8 @@ export class Solver{
             this.applyHint();
             // Resets allHints so getAllHints doesn't return Hints from prior step
             this.allHints = undefined;
+            // Updates empty cells
+            this.setEmptyCells();
             return this.hint;
         }
 

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -20,6 +20,8 @@ export class Solver{
     private solved: boolean;
     // Stores a hint corresponding to a step
     private hint: Hint;
+    // Stores hints for all strategies that are applicable at this step
+    private allHints: Hint[];
     // Stores order in which the Solver uses strategies to solve the Sudoku board (modified for testing strategies)
     private algorithm: StrategyEnum[];
 
@@ -59,10 +61,37 @@ export class Solver{
         this.setHint(this.emptyCells);
         if (this.hint !== null) {
             this.applyHint();
+            // Resets allHints so getAllHints doesn't return Hints from prior step
+            this.allHints = undefined;
             return this.hint;
         }
 
         throw new CustomError(CustomErrorEnum.UNSOLVABLE);
+    }
+
+    /**
+     * Gets an array containing Hint objects for each strategy that can be used at this step
+     * @returns array of Hints for all applicable strategies at this step
+     */
+    public getAllHints():Hint[] {
+        if (this.allHints === undefined) {
+            this.setAllHints();
+        }
+        return this.allHints;
+    }
+
+    /**
+     * Creates a Hint object for each strategy that can be used at this step and adds it to allHints
+     */
+    private setAllHints():void {
+        this.allHints = new Array();
+        for (let strategy: StrategyEnum = (StrategyEnum.INVALID + 1); strategy < StrategyEnum.COUNT; strategy++) {
+            let strategyObj:Strategy = new Strategy(this.board, this.emptyCells);
+            if (strategyObj.setStrategyType(strategy)) {
+                this.allHints.push(new Hint(strategyObj));
+            }
+        }
+        return;
     }
 
     /**

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -14,6 +14,8 @@ import { Group } from "./Group";
 export class Solver{
     // Stores representation of board being solved
     private board: Cell[][];
+    // Stores empty cells in board
+    private emptyCells: Cell[][];
     // Stores whether or not the board has been successfully solved
     private solved: boolean;
     // Stores a hint corresponding to a step
@@ -48,15 +50,15 @@ export class Solver{
      * Thrown if board is unsolvable
      */
     public nextStep():Hint {
-        let cells: Cell[][] = new Array();
-        this.initializeCellArray(cells, SudokuEnum.COLUMN_LENGTH);
-        this.addEveryEmptyCell(cells);
+        this.emptyCells = new Array();
+        this.initializeCellArray(this.emptyCells, SudokuEnum.COLUMN_LENGTH);
+        this.addEveryEmptyCell(this.emptyCells);
 
-        if (this.isFinished(cells)) {
+        if (this.isFinished(this.emptyCells)) {
             return null;
         }
 
-        this.setHint(cells);
+        this.setHint(this.emptyCells);
         if (this.hint !== null) {
             this.applyHint();
             return this.hint;

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -135,6 +135,7 @@ describe("solve Boards", () => {
     it('should solve single naked single', () => {
         expect(singleNakedSingle.getSolutionString()).toBe(TestBoards.SINGLE_NAKED_SINGLE_SOLUTION);
         expect(singleNakedSingle.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
+        expect((singleNakedSingle.getDrills()).length).toBe(1);
         for (let i:number = 0; i < StrategyEnum.COUNT; i++) {
             if (i === StrategyEnum.NAKED_SINGLE) {
                 expect(singleNakedSingle.getStrategies()[i]).toBeTruthy();

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -135,7 +135,15 @@ describe("solve Boards", () => {
     it('should solve single naked single', () => {
         expect(singleNakedSingle.getSolutionString()).toBe(TestBoards.SINGLE_NAKED_SINGLE_SOLUTION);
         expect(singleNakedSingle.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
-        expect((singleNakedSingle.getDrills()).length).toBe(1);
+        let drills:boolean[] = singleNakedSingle.getDrills();
+        for (let i:StrategyEnum = (StrategyEnum.INVALID + 1); i < StrategyEnum.COUNT; i++) {
+            if (i === StrategyEnum.NAKED_SINGLE) {
+                expect(drills[i]).toBeTruthy();
+            }
+            else {
+                expect(drills[i]).toBeFalsy();
+            }
+        }
         for (let i:number = 0; i < StrategyEnum.COUNT; i++) {
             if (i === StrategyEnum.NAKED_SINGLE) {
                 expect(singleNakedSingle.getStrategies()[i]).toBeTruthy();

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -157,6 +157,15 @@ describe("solve Boards", () => {
     it('should solve naked singles only board', () => {
         expect(onlyNakedSingles.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
         expect(onlyNakedSingles.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
+        let drills:boolean[] = onlyNakedSingles.getDrills();
+        for (let i:StrategyEnum = (StrategyEnum.INVALID + 1); i < StrategyEnum.COUNT; i++) {
+            if (i === StrategyEnum.HIDDEN_SINGLE || i === StrategyEnum.NAKED_SEXTUPLET) {
+                expect(drills[i]).toBeTruthy();
+            }
+            else {
+                expect(drills[i]).toBeFalsy();
+            }
+        }
     });
 
     it('should give higher difficulty rating to board with multiple naked singles than one with only one', () => {


### PR DESCRIPTION
Added getDrills to Board which returns boolean array representing strategies that can be used as first step in solving Board. Excludes prereqs of included strategies in order to make sure drills are good examples of given strategies e.g. don't want a naked pair drill to be two naked singles. Added getAllHints to Solver along with a small refactor to facilitate this feature. Added drills to unit tests.