### PR TITLE
Simplify notes strategy

### DIFF
--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -22,7 +22,6 @@ export class Board{
     private board: string[][];
     private solution: string[][];
     private solutionString: string;
-    private mostDifficultStrategy: StrategyEnum;
     private strategies: boolean[];
     private drills: boolean[];
     private difficulty: number;
@@ -47,7 +46,6 @@ export class Board{
 
         this.board = getBoardArray(board);
 
-        this.mostDifficultStrategy = -1;
         this.strategies = new Array(StrategyEnum.COUNT).fill(false);
         this.drills = new Array(StrategyEnum.COUNT).fill(false);
         this.difficulty = 0;
@@ -86,14 +84,6 @@ export class Board{
      */
     public getSolutionString():string {
         return this.solutionString;
-    }
-
-    /**
-     * Get strategy score
-     * @returns strategy score
-     */
-    public getStrategyScore():number {
-        return this.mostDifficultStrategy;
     }
 
     /**
@@ -207,10 +197,6 @@ export class Board{
             // Updates difficulty rating based on how hard current step is
             this.difficulty += hint.getDifficulty();
             stepCount++;
-            // Updates most difficult strategy used
-            if (hint.getStrategyType() > this.mostDifficultStrategy) {
-                this.mostDifficultStrategy = hint.getStrategyType();
-            }
             // Gets hint for next step
             hint = this.solver.nextStep();
         }

--- a/Generator/Board.ts
+++ b/Generator/Board.ts
@@ -126,8 +126,20 @@ export class Board{
      * For example, if there is a naked pair made up of two naked singles only the naked single will be used as a drill
      */
     private setDrills():void {
-        let hints:Hint[] = this.solver.getAllHints();
-        this.drills = new Array();
+        // Run through all of the simplify notes so drills that require notes to be removed can be added
+        let algorithm:StrategyEnum[] = new Array();
+        algorithm.push(StrategyEnum.SIMPLIFY_NOTES);
+        for (let i:number = (StrategyEnum.INVALID + 1); i < StrategyEnum.COUNT; i++) {
+            if (i !== StrategyEnum.SIMPLIFY_NOTES) {
+                algorithm.push(i);
+            }
+        }
+        let solver:Solver = new Solver(this.board, algorithm);
+        let hints:Hint[] = solver.getAllHints();
+        while ((solver.nextStep()).getStrategyType() === StrategyEnum.SIMPLIFY_NOTES) {
+            hints = solver.getAllHints();
+        }
+        this.drills = new Array(StrategyEnum.COUNT).fill(false);
         for (let i:number = 0; i < hints.length; i++) {
             this.drills[hints[i].getStrategyType()] = true;
         }
@@ -139,6 +151,7 @@ export class Board{
                 }
             }
         }
+        this.drills[StrategyEnum.SIMPLIFY_NOTES] = true;
         return;
     }
 

--- a/Generator/Demo/app.ts
+++ b/Generator/Demo/app.ts
@@ -43,6 +43,9 @@ app.get('/solver/nextStep', (req, res) => {
         else if (Number(req.query.nakedOctuplet) === i) {
             algorithm.push(StrategyEnum.NAKED_OCTUPLET);
         }
+        else if (Number(req.query.simplifyNotes) === i) {
+            algorithm.push(StrategyEnum.SIMPLIFY_NOTES);
+        }
     }
     let notes: string[][];
     if (req.query.notes !== "undefined") {

--- a/Generator/Demo/demo.html
+++ b/Generator/Demo/demo.html
@@ -150,5 +150,8 @@
         <br><br>
         <label for="nakedOctuplet">Naked Octuplet Order:</label>
         <input type="number" id="nakedOctuplet" value="9">
+        <br><br>
+        <label for="simplifyNotes">Simplify Notes Order:</label>
+        <input type="number" id="simplifyNotes" value="10">
     </body>
 </html>

--- a/Generator/Demo/script.ts
+++ b/Generator/Demo/script.ts
@@ -16,6 +16,7 @@ const NEXT_NAKED_QUINTUPLET:string = "&nakedQuintuplet=";
 const NEXT_NAKED_SEXTUPLET:string = "&nakedSextuplet=";
 const NEXT_NAKED_SEPTUPLET:string = "&nakedSeptuplet=";
 const NEXT_NAKED_OCTUPLET:string = "&nakedOctuplet=";
+const NEXT_SIMPLIFY_NOTES:string = "&simplifyNotes=";
 const CANDIDATES:string = "123456789";
 const EMPTY_CELL = "0";
 const SINGLE_NAKED_SINGLE = "439275618051896437876143592342687951185329746697451283928734165563912874714568329";
@@ -303,6 +304,9 @@ function getStrategyOrder():string {
 
     algorithm += NEXT_NAKED_OCTUPLET;
     algorithm += (<HTMLInputElement>document.getElementById("nakedOctuplet")).value;
+
+    algorithm += NEXT_SIMPLIFY_NOTES;
+    algorithm += (<HTMLInputElement>document.getElementById("simplifyNotes")).value;
 
     return algorithm;
 }

--- a/Generator/Hint.ts
+++ b/Generator/Hint.ts
@@ -94,6 +94,16 @@ export enum NAKED_OCTUPLET {
 }
 
 /**
+ * Contains hint information for simplify notes
+ * Contains what action hint is trying to get you to do
+ * @enum
+ */
+export enum SIMPLIFY_NOTES {
+    HINT_INFO = "You can simplify notes using values already placed in cells at the start of the game",
+    HINT_ACTION = "When there is a value already placed in a cell than it can be removed from all other cells notes in its row, column, and box"
+}
+
+/**
  * Constructed using strategy object and info/action strings
  * Inherited by hint classes for specific strategies like NakedSingle
  * Returns:
@@ -151,6 +161,10 @@ export class Hint{
         else if (this.getStrategyType() === StrategyEnum.HIDDEN_SINGLE) {
             this.info = HIDDEN_SINGLE.HINT_INFO;
             this.action = HIDDEN_SINGLE.HINT_ACTION;
+        }
+        else if (this.getStrategyType() === StrategyEnum.SIMPLIFY_NOTES) {
+            this.info = SIMPLIFY_NOTES.HINT_INFO;
+            this.action = SIMPLIFY_NOTES.HINT_ACTION;
         }
         else {
             throw new Error();

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -126,7 +126,7 @@ export class Solver{
     private setHint(cells: Cell[][]):void {
         // Attempts to use strategies in order specified by algorithm
         let strategy:Strategy = new Strategy(this.board, cells);
-        for (let i: number = 0; i < StrategyEnum.COUNT; i++) {
+        for (let i: number = 0; i < this.algorithm.length; i++) {
             if (strategy.setStrategyType(this.algorithm[i])) {
                 this.hint = new Hint(strategy);
                 return;

--- a/Generator/Solver.ts
+++ b/Generator/Solver.ts
@@ -35,10 +35,7 @@ export class Solver{
         this.board = new Array();
         this.initializeCellArray(this.board, board.length);
         this.initializeBoard(board);
-        if (notes === undefined) {
-            this.simplifyAllNotes();
-        }
-        else {
+        if (notes !== undefined) {
             this.setNotes(notes);
         }
         this.setEmptyCells();
@@ -217,72 +214,6 @@ export class Solver{
     }
 
     /**
-     * Simplify notes by removing filled cells values from rest of their row/column/boxes
-     */
-    private simplifyAllNotes():void {
-        for (let column:number = 0; column < SudokuEnum.ROW_LENGTH; column++) {
-            for (let row:number = 0; row < SudokuEnum.COLUMN_LENGTH; row++) {
-                if (!this.board[row][column].isEmpty()) {
-                    this.simplifyNotes(this.board[row][column]);
-                }
-            }
-        }
-    }
-
-    /**
-     * Removes cell's value from all other cells in its row/column/box
-     * 
-     * @param cell - cell that has had value placed in it
-     */
-    private simplifyNotes(cell: Cell):void {
-        let value:string = cell.getValue();
-
-        this.simplifyRowNotes(value, cell.getRow());
-        this.simplifyColumnNotes(value, cell.getColumn());
-        this.simplifyBoxNotes(value, cell.getBoxRowStart(), cell.getBoxColumnStart());
-    }
-
-    /**
-     * Removes given value from each cell in given row
-     * 
-     * @param value - value to remove
-     * @param row - row to remove value from
-     */
-    private simplifyRowNotes(value:string, row:number):void {
-        for (let column:number = 0; column < SudokuEnum.ROW_LENGTH; column++) {
-            this.board[row][column].removeNote(value);
-        }
-        return;
-    }
-
-    /**
-     * Removes given value from each cell in given column
-     * 
-     * @param value - value to remove
-     * @param column - column to remove value from
-     */
-    private simplifyColumnNotes(value:string, column:number):void {
-        for (let row:number = 0; row < SudokuEnum.COLUMN_LENGTH; row++) {
-            this.board[row][column].removeNote(value);
-        }
-        return;
-    }
-
-    /**
-     * Removes given value from each cell in given box
-     * 
-     * @param value - value to remove
-     * @param box - box to remove value from
-     */
-    private simplifyBoxNotes(value:string, row:number, column:number):void {
-        for (let r:number = row; r < (row + SudokuEnum.BOX_LENGTH); r++) {
-            for (let c:number = column; c < (column + SudokuEnum.BOX_LENGTH); c++) {
-                this.board[r][c].removeNote(value);
-            }
-        }
-    }
-
-    /**
      * Initializes 2d cell array
      * @param cells - 2d array to intialize
      * @param rowCount - number of rows in array
@@ -331,7 +262,6 @@ export class Solver{
             row = cells[i].getRow();
             column = cells[i].getColumn();
             this.board[row][column].setValue(cells[i].getValue());
-            this.simplifyNotes(this.board[row][column]);
         }
         return;
     }

--- a/Generator/Strategy.ts
+++ b/Generator/Strategy.ts
@@ -107,6 +107,9 @@ export class Strategy{
         else if (strategyType === StrategyEnum.HIDDEN_SINGLE) {
             return this.isHiddenSet(TupleEnum.SINGLE);
         }
+        else if (strategyType === StrategyEnum.SIMPLIFY_NOTES) {
+            return this.isSimplifyNotes();
+        }
         else {
             return false;
         }
@@ -437,7 +440,7 @@ export class Strategy{
      */
     private isSimplifyNotes():boolean {
         for (let i:number = 0; i < SudokuEnum.COLUMN_LENGTH; i++) {
-            for (let j:number = 0; this.cells[i].length; j++) {
+            for (let j:number = 0; j < this.cells[i].length; j++) {
                 let cell: Cell = this.cells[i][j];
                 let row: number = cell.getRow();
                 let column: number = cell.getColumn();

--- a/Generator/Strategy.ts
+++ b/Generator/Strategy.ts
@@ -400,6 +400,16 @@ export class Strategy{
                         let notHiddenSetCandidates:Group = getUnionOfSetNotes(notHiddenSet);
                         // Calculates notes that are in the hidden set
                         let hiddenSetCandidates:Group = getUnionOfSetNotes(hiddenSet);
+                        // Get values that have already been placed in the group and remove them as candidates
+                        let used:Group = new Group(false);
+                        let groupCells: Cell[] = getCellsInGroup(this.board, group, i);
+                        for (let k:number = 0; k < groupCells.length; k++) {
+                            if (!groupCells[k].isEmpty()) {
+                                used.insert(groupCells[k].getValue());
+                            }
+                        }
+                        notHiddenSetCandidates.remove(used);
+                        hiddenSetCandidates.remove(used);
                         // Is hidden set if correct number of candidates don't exist outside of the hidden set
                         if ((hiddenSetCandidates.getSize() - (hiddenSetCandidates.intersection(notHiddenSetCandidates)).getSize()) === tuple) {
                             // Remove candidates that aren't part of the hidden set from the hidden sets notes
@@ -472,7 +482,7 @@ export class Strategy{
                 if ((notes.intersection(cell.getNotes())).getSize() > 0) {
                     let notesToRemove: Group = new Group(false, row, column);
                     notesToRemove.insert(notes);
-                    this.notes.push(notes);
+                    this.notes.push(notesToRemove);
                     this.identified = true;
                     this.strategyType = StrategyEnum.SIMPLIFY_NOTES;
                     this.difficulty = DifficultyLowerBounds.SIMPLIFY_NOTES;

--- a/Generator/Strategy.ts
+++ b/Generator/Strategy.ts
@@ -16,7 +16,8 @@ enum DifficultyLowerBounds {
     NAKED_QUINTUPLET = 140,
     NAKED_SEXTUPLET = 200,
     NAKED_SEPTUPLET = 300,
-    NAKED_OCTUPLET = 450
+    NAKED_OCTUPLET = 450,
+    SIMPLIFY_NOTES = 10
 }
 
 /**
@@ -32,7 +33,8 @@ enum DifficultyUpperBounds {
     NAKED_QUINTUPLET = 140,
     NAKED_SEXTUPLET = 200,
     NAKED_SEPTUPLET = 300,
-    NAKED_OCTUPLET = 450
+    NAKED_OCTUPLET = 450,
+    SIMPLIFY_NOTES = 10
 }
 
 /**
@@ -423,6 +425,55 @@ export class Strategy{
                             }
                         }
                     }
+                }
+            }
+        }
+        return this.identified;
+    }
+
+    /**
+     * Checks if strategy is simplify notes and if so adds notes to remove from a cell
+     * @returns true if strategy is simplify notes
+     */
+    private isSimplifyNotes():boolean {
+        for (let i:number = 0; i < SudokuEnum.COLUMN_LENGTH; i++) {
+            for (let j:number = 0; this.cells[i].length; j++) {
+                let cell: Cell = this.cells[i][j];
+                let row: number = cell.getRow();
+                let column: number = cell.getColumn();
+                let box: number = cell.getBox();
+                let boxRowStart: number = Cell.getBoxRowStart(box);
+                let boxColumnStart: number = Cell.getBoxColumnStart(box);
+                let notes: Group = new Group(false);
+                // Add every placed value from given row
+                for (let k:number = 0; k < SudokuEnum.ROW_LENGTH; k++) {
+                    if (!this.board[row][k].isEmpty()) {
+                        notes.insert(this.board[row][k].getValue());
+                    }
+                }
+                // Add every placed value from given column
+                for (let k:number = 0; k < SudokuEnum.COLUMN_LENGTH; k++) {
+                    if (!this.board[k][column].isEmpty()) {
+                        notes.insert(this.board[k][column].getValue());
+                    }
+                }
+                // Add every placed value from given box
+                for (let r:number = boxRowStart; r < (boxRowStart + SudokuEnum.BOX_LENGTH); r++) {
+                    for (let c:number = boxColumnStart; c < (boxColumnStart + SudokuEnum.BOX_LENGTH); c++) {
+                        if (!this.board[r][c].isEmpty()) {
+                            notes.insert(this.board[r][c].getValue());
+                        }
+                    }
+                }
+                // If there are any notes to remove then strategy is identified
+                if ((notes.intersection(cell.getNotes())).getSize() > 0) {
+                    let notesToRemove: Group = new Group(false, row, column);
+                    notesToRemove.insert(notes);
+                    this.notes.push(notes);
+                    this.identified = true;
+                    this.strategyType = StrategyEnum.SIMPLIFY_NOTES;
+                    this.difficulty = DifficultyLowerBounds.SIMPLIFY_NOTES;
+                    return this.identified;
                 }
             }
         }

--- a/Generator/Sudoku.ts
+++ b/Generator/Sudoku.ts
@@ -31,6 +31,7 @@ export enum StrategyEnum {
     NAKED_SEXTUPLET,
     NAKED_SEPTUPLET,
     NAKED_OCTUPLET,
+    SIMPLIFY_NOTES,
     COUNT
 }
 

--- a/Generator/tests/unit/Board.test.ts
+++ b/Generator/tests/unit/Board.test.ts
@@ -121,7 +121,15 @@ let singleNakedSingle:Board, onlyNakedSingles:Board, onlyNakedSinglesQuadruplets
 describe("solve Boards", () => {
     beforeAll(() => {
         singleNakedSingle = new Board(TestBoards.SINGLE_NAKED_SINGLE);
-        onlyNakedSingles = new Board(TestBoards.ONLY_NAKED_SINGLES);
+        let nakedSingleAlgo:StrategyEnum[] = new Array();
+        nakedSingleAlgo.push(StrategyEnum.NAKED_SINGLE);
+        nakedSingleAlgo.push(StrategyEnum.SIMPLIFY_NOTES);
+        for (let strategy: number = 0; strategy < StrategyEnum.COUNT; strategy++) {
+            if (strategy !== StrategyEnum.NAKED_SINGLE && strategy !== StrategyEnum.SIMPLIFY_NOTES) {
+                nakedSingleAlgo.push(strategy);
+            }
+        }
+        onlyNakedSingles = new Board(TestBoards.ONLY_NAKED_SINGLES, nakedSingleAlgo);
         let algorithm:StrategyEnum[] = new Array();
         algorithm.push(StrategyEnum.NAKED_QUADRUPLET);
         for (let strategy: number = 0; strategy < StrategyEnum.COUNT; strategy++) {
@@ -134,10 +142,9 @@ describe("solve Boards", () => {
 
     it('should solve single naked single', () => {
         expect(singleNakedSingle.getSolutionString()).toBe(TestBoards.SINGLE_NAKED_SINGLE_SOLUTION);
-        expect(singleNakedSingle.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
         let drills:boolean[] = singleNakedSingle.getDrills();
         for (let i:StrategyEnum = (StrategyEnum.INVALID + 1); i < StrategyEnum.COUNT; i++) {
-            if (i === StrategyEnum.NAKED_SINGLE) {
+            if (i === StrategyEnum.NAKED_SINGLE || i === StrategyEnum.SIMPLIFY_NOTES) {
                 expect(drills[i]).toBeTruthy();
             }
             else {
@@ -145,7 +152,7 @@ describe("solve Boards", () => {
             }
         }
         for (let i:number = 0; i < StrategyEnum.COUNT; i++) {
-            if (i === StrategyEnum.NAKED_SINGLE) {
+            if (i === StrategyEnum.NAKED_SINGLE || i === StrategyEnum.SIMPLIFY_NOTES) {
                 expect(singleNakedSingle.getStrategies()[i]).toBeTruthy();
             }
             else {
@@ -156,10 +163,18 @@ describe("solve Boards", () => {
 
     it('should solve naked singles only board', () => {
         expect(onlyNakedSingles.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
-        expect(onlyNakedSingles.getStrategyScore()).toBe(StrategyEnum.NAKED_SINGLE);
+        let strategies:boolean[] = onlyNakedSingles.getStrategies();
+        for (let i:number = 0; i < strategies.length; i++) {
+            if (i === StrategyEnum.NAKED_SINGLE || i === StrategyEnum.SIMPLIFY_NOTES) {
+                expect(strategies[i]).toBeTruthy();
+            }
+            else {
+                expect(strategies[i]).toBeFalsy();
+            }
+        }
         let drills:boolean[] = onlyNakedSingles.getDrills();
         for (let i:StrategyEnum = (StrategyEnum.INVALID + 1); i < StrategyEnum.COUNT; i++) {
-            if (i === StrategyEnum.HIDDEN_SINGLE || i === StrategyEnum.NAKED_SEXTUPLET) {
+            if (i === StrategyEnum.HIDDEN_SINGLE || i === StrategyEnum.NAKED_SEXTUPLET || i === StrategyEnum.SIMPLIFY_NOTES) {
                 expect(drills[i]).toBeTruthy();
             }
             else {
@@ -174,14 +189,16 @@ describe("solve Boards", () => {
 
     it ('should solve row hidden single', () => {
         let board:Board = new Board(TestBoards.ROW_HIDDEN_SINGLES);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.ROW_HIDDEN_SINGLES_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.HIDDEN_SINGLE);
+        expect(strategies[StrategyEnum.HIDDEN_SINGLE]).toBeTruthy();
     });
 
     it ('should solve row column box hidden singles', () => {
         let board:Board = new Board(TestBoards.ROW_COLUMN_BOX_HIDDEN_SINGLES);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.ROW_COLUMN_BOX_HIDDEN_SINGLES_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.HIDDEN_SINGLE);
+        expect(strategies[StrategyEnum.HIDDEN_SINGLE]).toBeTruthy();
     });
 
     it('should solve row naked pair', () => {
@@ -193,31 +210,36 @@ describe("solve Boards", () => {
             }
         }
         let board:Board = new Board(TestBoards.ROW_NAKED_PAIR, algorithm);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.ROW_NAKED_PAIR_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_PAIR);
+        expect(strategies[StrategyEnum.NAKED_PAIR]).toBeTruthy();
     });
 
     it('should solve column naked pair', () => {
         let board:Board = new Board(TestBoards.COLUMN_NAKED_PAIR);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.COLUMN_NAKED_PAIR_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_PAIR);
+        expect(strategies[StrategyEnum.NAKED_PAIR]).toBeTruthy();
     });
 
     it('should solve box naked pair', () => {
         let board:Board = new Board(TestBoards.BOX_NAKED_PAIR);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.BOX_NAKED_PAIR_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_PAIR);
+        expect(strategies[StrategyEnum.NAKED_PAIR]).toBeTruthy();
     });
 
     it('should solve naked triplet', () => {
         let board:Board = new Board(TestBoards.NAKED_TRIPLET);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.NAKED_TRIPLET_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_TRIPLET);
+        expect(strategies[StrategyEnum.NAKED_TRIPLET]).toBeTruthy();
     });
 
     it('should solve naked quadruplet', () => {
+        let strategies:boolean[] = onlyNakedSinglesQuadruplets.getStrategies();
         expect(onlyNakedSinglesQuadruplets.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
-        expect(onlyNakedSinglesQuadruplets.getStrategyScore()).toBe(StrategyEnum.NAKED_QUADRUPLET);
+        expect(strategies[StrategyEnum.NAKED_QUADRUPLET]).toBeTruthy();
     });
 
     it('should give a higher difficulty score to solving same board with naked quadruplets than singles', () => {
@@ -234,53 +256,52 @@ describe("solve Boards", () => {
         }
         let board:Board = new Board(TestBoards.ONLY_NAKED_SINGLES, algorithm);
         let strategies:boolean[] = board.getStrategies();
-        let strategyCount:number = 0;
-        for (let i:number = 0; i < StrategyEnum.COUNT; i++) {
-            if (strategies[i]) {
-                strategyCount++;
-            }
-        }
         expect(board.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_QUINTUPLET);
-        expect(strategyCount).toBe(5);
+        expect(strategies[StrategyEnum.NAKED_QUINTUPLET]).toBeTruthy();
     });
 
     it('should solve naked sextuplet', () => {
         let algorithm:StrategyEnum[] = new Array();
+        algorithm.push(StrategyEnum.SIMPLIFY_NOTES);
         algorithm.push(StrategyEnum.NAKED_SEXTUPLET);
         for (let strategy: number = 0; strategy < StrategyEnum.COUNT; strategy++) {
-            if (strategy !== StrategyEnum.NAKED_SEXTUPLET) {
+            if (strategy !== StrategyEnum.NAKED_SEXTUPLET && strategy !== StrategyEnum.SIMPLIFY_NOTES) {
                 algorithm.push(strategy);
             }
         }
         let board:Board = new Board(TestBoards.ONLY_NAKED_SINGLES, algorithm);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.ONLY_NAKED_SINGLES_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_SEXTUPLET);
+        expect(strategies[StrategyEnum.NAKED_SEXTUPLET]).toBeTruthy();
     });
 
     it('should solve naked septuplet', () => {
         let algorithm:StrategyEnum[] = new Array();
+        algorithm.push(StrategyEnum.SIMPLIFY_NOTES);
         algorithm.push(StrategyEnum.NAKED_SEPTUPLET);
         for (let strategy: number = 0; strategy < StrategyEnum.COUNT; strategy++) {
-            if (strategy !== StrategyEnum.NAKED_SEPTUPLET) {
+            if (strategy !== StrategyEnum.NAKED_SEPTUPLET && strategy !== StrategyEnum.SIMPLIFY_NOTES) {
                 algorithm.push(strategy);
             }
         }
         let board:Board = new Board(TestBoards.COLUMN_NAKED_PAIR, algorithm);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.COLUMN_NAKED_PAIR_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_SEPTUPLET);
+        expect(strategies[StrategyEnum.NAKED_SEPTUPLET]).toBeTruthy();
     });
 
     it('should solve naked octuplet', () => {
         let algorithm:StrategyEnum[] = new Array();
+        algorithm.push(StrategyEnum.SIMPLIFY_NOTES);
         algorithm.push(StrategyEnum.NAKED_OCTUPLET);
         for (let strategy: number = 0; strategy < StrategyEnum.COUNT; strategy++) {
-            if (strategy !== StrategyEnum.NAKED_OCTUPLET) {
+            if (strategy !== StrategyEnum.NAKED_OCTUPLET && strategy !== StrategyEnum.SIMPLIFY_NOTES) {
                 algorithm.push(strategy);
             }
         }
         let board:Board = new Board(TestBoards.NAKED_OCTUPLET, algorithm);
+        let strategies:boolean[] = board.getStrategies();
         expect(board.getSolutionString()).toBe(TestBoards.NAKED_OCTUPLET_SOLUTION);
-        expect(board.getStrategyScore()).toBe(StrategyEnum.NAKED_OCTUPLET);
+        expect(strategies[StrategyEnum.NAKED_OCTUPLET]).toBeTruthy();
     });
 });


### PR DESCRIPTION
This pull request is to make simplify notes a strategy and given the lowest priority. This will break many test cases as it will mess up the strategy score but those tests really need to switch to strategies boolean anyways and have fixed algorithms (and need to change Solver to only use algorithm length instead of strategy enum length).

Nice thing about setting up simplifying this way with lowest priority is that hints will focus on the cells you are already working on.